### PR TITLE
fix: add Timepoint branding for Mintlify docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "Timepoint Flash",
+  "logo": {
+    "dark": "/logo/logo-full-dark.svg",
+    "light": "/logo/logo-full.svg"
+  },
+  "favicon": "/logo/favicon.svg",
+  "colors": {
+    "primary": "#d4a24e",
+    "light": "#f0c05e",
+    "dark": "#a67c30"
+  }
+}

--- a/logo/favicon.svg
+++ b/logo/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#06080d"/>
+  <g fill="none" transform="translate(16,16)">
+    <polygon points="0,-13 11.26,-6.5 11.26,6.5 0,13 -11.26,6.5 -11.26,-6.5" stroke="#c9a84c" stroke-width="0.9"/>
+    <polygon points="7.5,-4.33 7.5,4.33 0,8.66 -7.5,4.33 -7.5,-4.33 0,-8.66" stroke="#c9a84c" stroke-width="0.55" opacity="0.55"/>
+    <line x1="0" y1="-13" x2="0" y2="13" stroke="#c9a84c" stroke-width="0.35" opacity="0.25"/>
+    <line x1="-11.26" y1="-6.5" x2="11.26" y2="6.5" stroke="#c9a84c" stroke-width="0.35" opacity="0.25"/>
+    <line x1="-11.26" y1="6.5" x2="11.26" y2="-6.5" stroke="#c9a84c" stroke-width="0.35" opacity="0.25"/>
+    <circle cx="0" cy="0" r="3" stroke="#c9a84c" stroke-width="0.4" opacity="0.4"/>
+    <circle cx="0" cy="0" r="1.2" fill="#c9a84c" opacity="0.7"/>
+  </g>
+</svg>

--- a/logo/logo-full-dark.svg
+++ b/logo/logo-full-dark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 48">
+  <rect width="260" height="48" rx="4" fill="#06080d"/>
+  <g fill="none" transform="translate(24,24)">
+    <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" stroke="#c9a84c" stroke-width="1.4"/>
+    <polygon points="11.55,-6.67 11.55,6.67 0,13.33 -11.55,6.67 -11.55,-6.67 0,-13.33" stroke="#c9a84c" stroke-width="0.8" opacity="0.55"/>
+    <line x1="0" y1="-20" x2="0" y2="20" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <line x1="-17.32" y1="-10" x2="17.32" y2="10" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <line x1="-17.32" y1="10" x2="17.32" y2="-10" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <circle cx="0" cy="0" r="4.5" stroke="#c9a84c" stroke-width="0.6" opacity="0.4"/>
+    <circle cx="0" cy="0" r="1.8" fill="#c9a84c" opacity="0.7"/>
+  </g>
+  <text x="56" y="30" fill="#e8e0d0" font-family="'Cormorant Garamond', Georgia, serif" font-size="22" font-weight="600" letter-spacing="0.08em">TIMEPOINT</text>
+</svg>

--- a/logo/logo-full.svg
+++ b/logo/logo-full.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 48">
+  <g fill="none" transform="translate(24,24)">
+    <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" stroke="#c9a84c" stroke-width="1.4"/>
+    <polygon points="11.55,-6.67 11.55,6.67 0,13.33 -11.55,6.67 -11.55,-6.67 0,-13.33" stroke="#c9a84c" stroke-width="0.8" opacity="0.55"/>
+    <line x1="0" y1="-20" x2="0" y2="20" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <line x1="-17.32" y1="-10" x2="17.32" y2="10" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <line x1="-17.32" y1="10" x2="17.32" y2="-10" stroke="#c9a84c" stroke-width="0.5" opacity="0.25"/>
+    <circle cx="0" cy="0" r="4.5" stroke="#c9a84c" stroke-width="0.6" opacity="0.4"/>
+    <circle cx="0" cy="0" r="1.8" fill="#c9a84c" opacity="0.7"/>
+  </g>
+  <text x="56" y="30" fill="#e8e0d0" font-family="'Cormorant Garamond', Georgia, serif" font-size="22" font-weight="600" letter-spacing="0.08em">TIMEPOINT</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds `docs.json` with Timepoint logo configuration
- Adds `logo/` directory with light, dark, and favicon SVGs
- Overrides default Mintlify discovery branding (was showing X AI logo)

## Test plan
- [ ] Verify Mintlify auto-docs rebuild with Timepoint branding

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>