### PR TITLE
fix: resolve CharacterBioAgent attribute errors and CritiqueOutput validation

### DIFF
--- a/app/agents/character_bio.py
+++ b/app/agents/character_bio.py
@@ -148,8 +148,8 @@ class CharacterBioAgent(BaseAgent[CharacterBioInput, Character]):
                 rel_lines = []
                 for rel in relationships:
                     rel_lines.append(
-                        f"- {rel.character_a} <-> {rel.character_b}: "
-                        f"{rel.relationship_type} ({rel.emotional_tone})"
+                        f"- {rel.from_character} <-> {rel.to_character}: "
+                        f"{rel.relationship_type} ({rel.tension_level})"
                     )
                 relationship_context = "\n".join(rel_lines)
 

--- a/app/agents/critique.py
+++ b/app/agents/critique.py
@@ -88,12 +88,18 @@ class CritiqueIssue(BaseModel):
             # error_type -> category
             if "category" not in data and "error_type" in data:
                 data["category"] = data.pop("error_type")
+            # Default category if LLM omits it entirely
+            if "category" not in data:
+                data["category"] = "general"
             # specific_error / specific_issue -> description
             if "description" not in data:
-                for alt in ("specific_error", "specific_issue", "issue"):
+                for alt in ("specific_error", "specific_issue", "issue", "reasoning"):
                     if alt in data:
                         data["description"] = data.pop(alt)
                         break
+            # Default description from fix_suggestion if still missing
+            if "description" not in data and "fix_suggestion" in data:
+                data["description"] = data["fix_suggestion"]
         return data
 
 


### PR DESCRIPTION
## Summary

- **CharacterBioAgent**: Fixed attribute errors when accessing `Relationship` schema fields. The schema uses `from_character`/`to_character`/`tension_level`, not `character_a`/`character_b`/`emotional_tone`.
- **CritiqueOutput validator**: Hardened the `normalize_field_names` validator to handle more LLM response variations:
  - Defaults `category` to `"general"` when the LLM omits it entirely
  - Accepts `"reasoning"` as an additional alternative for `description`
  - Falls back to `fix_suggestion` for `description` when all other alternatives are missing

## Test plan

- [ ] Run `pytest -m fast -v` to verify no regressions
- [ ] Run a generation pipeline end-to-end to confirm CharacterBioAgent no longer raises `AttributeError`
- [ ] Verify CritiqueOutput accepts LLM responses missing `category` or `description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)