### PR TITLE
fix: repair image generation fallback chain

### DIFF
--- a/app/core/llm_router.py
+++ b/app/core/llm_router.py
@@ -74,11 +74,11 @@ PAID_FALLBACK_MODEL = VerifiedModels.OPENROUTER_TEXT[0]  # google/gemini-2.0-fla
 
 # OpenRouter fallback image model when Google quota is exhausted
 # Uses Flux Schnell for fast, quality image generation
-OPENROUTER_IMAGE_FALLBACK = "black-forest-labs/flux-schnell"
+OPENROUTER_IMAGE_FALLBACK = "google/gemini-2.5-flash-image-preview"
 
 # Pollinations.ai - Ultimate free fallback for image generation
 # No API key required, always available, decent quality
-POLLINATIONS_URL = "https://image.pollinations.ai/prompt/{prompt}"
+POLLINATIONS_URL = "https://gen.pollinations.ai/image/{prompt}"
 POLLINATIONS_TIMEOUT = 60.0  # Image generation can take time
 
 # Rate limit retry settings
@@ -790,8 +790,8 @@ class LLMRouter:
         url = POLLINATIONS_URL.format(prompt=encoded_prompt)
 
         # Add parameters for better quality
-        # nologo=true removes watermark, width/height for resolution
-        url += "?nologo=true&width=1024&height=1024"
+        # nologo=true removes watermark, width/height for resolution, model=flux for best quality
+        url += "?nologo=true&width=1024&height=1024&model=flux"
 
         logger.info(f"Pollinations.ai fallback: generating image for prompt (first 50 chars): {prompt[:50]}...")
 

--- a/app/core/providers/openrouter.py
+++ b/app/core/providers/openrouter.py
@@ -196,7 +196,7 @@ class OpenRouterProvider(LLMProvider):
                 m
                 for m in models
                 if m.architecture
-                and capability in m.architecture.get("modality", "")
+                and capability in (m.architecture.get("output_modalities") or [])
             ]
 
         return models


### PR DESCRIPTION
## Summary

- **OpenRouter image fallback**: Replace `black-forest-labs/flux-schnell` with `google/gemini-2.5-flash-image-preview` — flux-schnell was removed from OpenRouter and is no longer available as a fallback model
- **Pollinations URL migration**: Update base URL from `image.pollinations.ai` to `gen.pollinations.ai` (Pollinations migrated their API domain) and add `model=flux` parameter for best image quality
- **OpenRouter capability filter**: Fix `list_models` to check `output_modalities` (a list) instead of the deprecated `modality` string field, which caused capability filtering to silently return no results

## Test plan

- [ ] Verify image generation works when Google quota is exhausted (OpenRouter fallback)
- [ ] Verify image generation works when both Google and OpenRouter fail (Pollinations fallback)
- [ ] Verify `list_models` with capability filter returns expected models from OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)