### PR TITLE
fix: prevent slug collision on long queries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -111,10 +111,12 @@ def generate_slug(query: str, year: int | None = None) -> str:
 
     # Add unique suffix (first 6 chars of UUID)
     unique_suffix = str(uuid.uuid4())[:6]
-    slug = f"{slug}-{unique_suffix}"
 
-    # Limit length
-    return slug[:100]
+    # Truncate base slug to leave room for the suffix, then append
+    max_base = 100 - len(unique_suffix) - 1  # -1 for the hyphen
+    slug = f"{slug[:max_base]}-{unique_suffix}"
+
+    return slug
 
 
 class Timepoint(Base):


### PR DESCRIPTION
## Summary
- Long queries (e.g. meeting agendas) generate slugs exceeding 100 chars
- The UUID suffix was appended *before* truncation, so it got cut off entirely
- This made duplicate long queries produce identical slugs, causing `UniqueViolationError`
- Fix: truncate the base slug first to leave room for the 6-char UUID suffix

## Repro
Generate two timepoints with the same long query (>93 chars). The second insert crashes with `duplicate key value violates unique constraint "ix_timepoints_slug"`.

## Test plan
- [x] `pytest -m fast` passes (547 tests)
- [x] Verified fix deployed on flash-deploy-private (production)