### PR TITLE
fix: prevent image generation failures from killing the SSE stream

### DIFF
--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -194,10 +194,15 @@ class PipelineState:
         """Check if any critical step failed.
 
         Non-critical steps (failures don't block the pipeline):
-        - IMAGE_GENERATION: User still gets all valuable text content
+        - IMAGE_PROMPT / IMAGE_PROMPT_OPTIMIZE / IMAGE_GENERATION: User still gets all text content
         - GROUNDING: Pipeline continues without verified facts (falls back to LLM knowledge)
         """
-        non_critical_steps = {PipelineStep.IMAGE_GENERATION, PipelineStep.GROUNDING}
+        non_critical_steps = {
+            PipelineStep.IMAGE_PROMPT,
+            PipelineStep.IMAGE_PROMPT_OPTIMIZE,
+            PipelineStep.IMAGE_GENERATION,
+            PipelineStep.GROUNDING,
+        }
         return any(
             not r.success and r.step not in non_critical_steps
             for r in self.step_results
@@ -909,16 +914,15 @@ class GenerationPipeline:
         # Step 9: Image Prompt (uses ALL data)
         state = await self._step_image_prompt(state)
         yield (PipelineStep.IMAGE_PROMPT, state.step_results[-1], state)
-        if state.has_errors:
-            logger.warning(f"Pipeline has errors after image_prompt, skipping image generation")
-            return
 
-        # Step 10: Image Generation (optional)
+        # Step 10: Image Generation (optional, never blocks the stream)
         logger.info(f"Image generation check: generate_image={generate_image}")
-        if generate_image:
+        if generate_image and not state.has_critical_errors:
             logger.info("Running image generation step...")
             state = await self._step_image_generation(state)
             yield (PipelineStep.IMAGE_GENERATION, state.step_results[-1], state)
+        elif generate_image and state.has_critical_errors:
+            logger.warning("Skipping image generation due to critical pipeline errors")
         else:
             logger.info("Skipping image generation (not requested)")
 


### PR DESCRIPTION
## Summary
- Image-related steps (prompt, optimize, generation) are now non-critical
- The stream always completes and sends a done event with the timepoint, even if image generation fails
- Previously, any accumulated error at the image_prompt checkpoint would `return` early from the generator, hanging the SSE stream with no done event

## Root cause
`run_streaming()` checked `state.has_errors` (catches ANY failure) instead of `state.has_critical_errors` after the image_prompt step. If any non-critical step had failed earlier (e.g. grounding), the generator returned early — no done event, no DB save, SSE hangs.

## Test plan
- [x] `pytest -m fast` passes
- [x] Verified fix deployed on flash-deploy-private (production)