### PR TITLE
feat(openrouter): multi-key fallback chain via OPENROUTER_API_KEYS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -356,12 +356,14 @@ class Settings(BaseSettings):
     """Application settings with provider configuration.
 
     Settings are loaded from environment variables and .env file.
-    At least one provider API key (GOOGLE_API_KEY or OPENROUTER_API_KEY) is required.
+    At least one provider API key (GOOGLE_API_KEY, OPENROUTER_API_KEY, or
+    OPENROUTER_API_KEYS) is required.
 
     Attributes:
         DATABASE_URL: Database connection string (SQLite or PostgreSQL)
         GOOGLE_API_KEY: Google AI API key for Gemini models
-        OPENROUTER_API_KEY: OpenRouter API key for multi-model access
+        OPENROUTER_API_KEY: OpenRouter API key (singular, fallback when OPENROUTER_API_KEYS unset)
+        OPENROUTER_API_KEYS: Comma-separated OpenRouter API keys for multi-key fallback chain
         PRIMARY_PROVIDER: Primary LLM provider (google or openrouter)
         FALLBACK_PROVIDER: Fallback provider when primary fails
         JUDGE_MODEL: Model for fast validation/judging tasks
@@ -389,7 +391,15 @@ class Settings(BaseSettings):
     )
     OPENROUTER_API_KEY: str | None = Field(
         default=None,
-        description="OpenRouter API key",
+        description="OpenRouter API key (singular fallback — used when OPENROUTER_API_KEYS is not set)",
+    )
+    OPENROUTER_API_KEYS: str | None = Field(
+        default=None,
+        description=(
+            "Comma-separated list of OpenRouter API keys for multi-key fallback. "
+            "When set, preferred over OPENROUTER_API_KEY. Keys are tried in order; "
+            "a key is skipped on HTTP 401/402/429 or network/timeout errors."
+        ),
     )
     STABILITY_API_KEY: str | None = Field(
         default=None,
@@ -614,14 +624,45 @@ class Settings(BaseSettings):
         # Soft validation - just track if any providers are available
         # The app will start but providers will be marked as unavailable
         self._has_any_provider = bool(
-            self.GOOGLE_API_KEY or self.OPENROUTER_API_KEY or self.STABILITY_API_KEY
+            self.GOOGLE_API_KEY or self.OPENROUTER_API_KEY or self.OPENROUTER_API_KEYS or self.STABILITY_API_KEY
         )
         return self
 
     @property
+    def openrouter_keys(self) -> list[str]:
+        """Return the ordered list of OpenRouter API keys for fallback iteration.
+
+        Prefers OPENROUTER_API_KEYS (comma-separated plural) over the singular
+        OPENROUTER_API_KEY. De-duplicates and strips empty values. Falls back to
+        OPENROUTER_API_KEY if OPENROUTER_API_KEYS is unset or empty.
+
+        Returns:
+            list[str]: Ordered, de-duplicated list of valid API keys.
+
+        Examples:
+            >>> # With OPENROUTER_API_KEYS="key1,key2,key3"
+            >>> settings.openrouter_keys  # ["key1", "key2", "key3"]
+            >>> # With only OPENROUTER_API_KEY="key1"
+            >>> settings.openrouter_keys  # ["key1"]
+        """
+        raw: list[str] = []
+        if self.OPENROUTER_API_KEYS:
+            raw = [k.strip() for k in self.OPENROUTER_API_KEYS.split(",") if k.strip()]
+        if not raw and self.OPENROUTER_API_KEY:
+            raw = [self.OPENROUTER_API_KEY]
+        # De-duplicate while preserving insertion order
+        seen: set[str] = set()
+        result: list[str] = []
+        for k in raw:
+            if k not in seen:
+                seen.add(k)
+                result.append(k)
+        return result
+
+    @property
     def has_any_provider(self) -> bool:
         """Check if any provider API key is configured."""
-        return bool(self.GOOGLE_API_KEY or self.OPENROUTER_API_KEY or self.STABILITY_API_KEY)
+        return bool(self.GOOGLE_API_KEY or self.openrouter_keys or self.STABILITY_API_KEY)
 
     @property
     def is_production(self) -> bool:
@@ -645,7 +686,7 @@ class Settings(BaseSettings):
         """
         if self.GOOGLE_API_KEY:
             return ProviderType.GOOGLE
-        elif self.OPENROUTER_API_KEY:
+        elif self.openrouter_keys:
             return ProviderType.OPENROUTER
         raise ValueError("No API keys configured")
 
@@ -661,7 +702,7 @@ class Settings(BaseSettings):
         if provider == ProviderType.GOOGLE:
             return bool(self.GOOGLE_API_KEY)
         elif provider == ProviderType.OPENROUTER:
-            return bool(self.OPENROUTER_API_KEY)
+            return bool(self.openrouter_keys)
         elif provider == ProviderType.STABILITY:
             return bool(self.STABILITY_API_KEY)
         return False
@@ -683,9 +724,10 @@ class Settings(BaseSettings):
                 raise ValueError("GOOGLE_API_KEY not configured")
             return self.GOOGLE_API_KEY
         elif provider == ProviderType.OPENROUTER:
-            if not self.OPENROUTER_API_KEY:
+            keys = self.openrouter_keys
+            if not keys:
                 raise ValueError("OPENROUTER_API_KEY not configured")
-            return self.OPENROUTER_API_KEY
+            return keys[0]
         elif provider == ProviderType.STABILITY:
             if not self.STABILITY_API_KEY:
                 raise ValueError("STABILITY_API_KEY not configured")

--- a/app/config.py
+++ b/app/config.py
@@ -624,7 +624,10 @@ class Settings(BaseSettings):
         # Soft validation - just track if any providers are available
         # The app will start but providers will be marked as unavailable
         self._has_any_provider = bool(
-            self.GOOGLE_API_KEY or self.OPENROUTER_API_KEY or self.OPENROUTER_API_KEYS or self.STABILITY_API_KEY
+            self.GOOGLE_API_KEY
+            or self.OPENROUTER_API_KEY
+            or self.OPENROUTER_API_KEYS
+            or self.STABILITY_API_KEY
         )
         return self
 

--- a/app/core/llm_router.py
+++ b/app/core/llm_router.py
@@ -279,9 +279,12 @@ class LLMRouter:
 
         if settings.has_provider(ProviderType.OPENROUTER):
             self.providers[ProviderType.OPENROUTER] = OpenRouterProvider(
-                api_key=settings.OPENROUTER_API_KEY
+                api_keys=settings.openrouter_keys
             )
-            logger.info("Initialized OpenRouter provider")
+            logger.info(
+                "Initialized OpenRouter provider with %d key(s)",
+                len(settings.openrouter_keys),
+            )
 
         if settings.has_provider(ProviderType.STABILITY):
             self.providers[ProviderType.STABILITY] = StabilityProvider(

--- a/app/core/providers/openrouter.py
+++ b/app/core/providers/openrouter.py
@@ -5,6 +5,13 @@ Supports 300+ models including Claude, GPT-4, Llama, and more.
 
 OpenRouter API docs: https://openrouter.ai/docs
 
+Multi-key fallback: When multiple keys are supplied via OPENROUTER_API_KEYS
+(comma-separated) the provider iterates through them automatically on
+HTTP 401/402/429 or network/timeout errors, logging a WARN with the last-8-char
+key fingerprint before advancing. On a non-retriable error (e.g. 400 bad model)
+execution stops immediately. If all keys are exhausted an ERROR is logged and
+the last error is re-raised.
+
 Examples:
     >>> from app.core.providers.openrouter import OpenRouterProvider
     >>> provider = OpenRouterProvider(api_key="sk-or-v1-...")
@@ -16,6 +23,7 @@ Examples:
 Tests:
     - tests/unit/test_providers.py::test_openrouter_provider_init
     - tests/unit/test_providers.py::test_openrouter_provider_call_text
+    - tests/unit/test_openrouter_multikey.py  (multi-key fallback matrix)
     - tests/integration/test_llm_router.py::test_openrouter_provider_integration
 """
 
@@ -45,6 +53,9 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
 OPENROUTER_CHAT_URL = f"{OPENROUTER_BASE_URL}/chat/completions"
 
+# HTTP status codes that trigger key rotation (try next key)
+_RETRIABLE_AUTH_STATUSES: frozenset[int] = frozenset({401, 402, 429})
+
 
 class OpenRouterModel(BaseModel):
     """OpenRouter model metadata.
@@ -70,9 +81,12 @@ class OpenRouterProvider(LLMProvider):
     Provides access to 300+ models via OpenRouter's unified API.
     Supports dynamic model discovery and real-time pricing.
 
+    When initialised with multiple keys (via ``api_keys``) the provider
+    iterates through them on auth/rate/network failures so that a single
+    exhausted or revoked key does not block generation.
+
     Attributes:
         provider_type: ProviderType.OPENROUTER
-        api_key: OpenRouter API key
         base_url: API base URL
 
     Available via OpenRouter:
@@ -95,31 +109,47 @@ class OpenRouterProvider(LLMProvider):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str = "",
+        api_keys: list[str] | None = None,
         base_url: str = OPENROUTER_BASE_URL,
         timeout: float = 60.0,
     ) -> None:
         """Initialize OpenRouter provider.
 
         Args:
-            api_key: OpenRouter API key.
+            api_key: Single OpenRouter API key (backward-compatible, used when
+                     api_keys is not supplied).
+            api_keys: Ordered list of OpenRouter API keys for multi-key fallback.
+                      When supplied, takes precedence over api_key.
             base_url: API base URL (default: https://openrouter.ai/api/v1).
             timeout: Request timeout in seconds.
         """
-        super().__init__(api_key)
+        # Build internal key list (plural wins over singular)
+        if api_keys:
+            self._keys: list[str] = [k for k in api_keys if k]
+        elif api_key:
+            self._keys = [api_key]
+        else:
+            self._keys = []
+
+        # Pass first key (or empty) to base class for backward compat
+        super().__init__(self._keys[0] if self._keys else "")
         self.base_url = base_url
         self.timeout = timeout
         self._client: httpx.AsyncClient | None = None
 
     @property
     def client(self) -> httpx.AsyncClient:
-        """Get httpx async client (lazy initialization)."""
+        """Get httpx async client (lazy initialization).
+
+        Note: Authorization is intentionally omitted from client-level headers
+        so that per-request keys can be supplied without re-creating the client.
+        """
         if self._client is None or self._client.is_closed:
             self._client = httpx.AsyncClient(
                 base_url=self.base_url,
                 timeout=self.timeout,
                 headers={
-                    "Authorization": f"Bearer {self.api_key}",
                     "HTTP-Referer": "https://timepoint.ai",
                     "X-Title": "TIMEPOINT Flash",
                     "Content-Type": "application/json",
@@ -166,6 +196,102 @@ class OpenRouterProvider(LLMProvider):
                 retryable=response.status_code >= 500,
             )
 
+    async def _post_with_key_fallback(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+    ) -> httpx.Response:
+        """POST to *endpoint* iterating keys on auth/rate/network failures.
+
+        For each key in ``self._keys``:
+        - On HTTP 200: return the response immediately.
+        - On HTTP 401/402/429: log WARN (key fingerprint + status), try next.
+        - On network/timeout: log WARN (key fingerprint + error), try next.
+        - On any other non-200 HTTP status: return the response so the caller
+          can invoke ``_handle_error`` (e.g. 400 bad model — non-retriable).
+
+        After all keys are exhausted:
+        - Log ERROR with exhausted-key count.
+        - Re-raise the last network exception if one occurred, otherwise call
+          ``_handle_error`` on the last non-200 response.
+
+        Args:
+            endpoint: Relative URL path (e.g. "/chat/completions").
+            payload: JSON-serialisable request body.
+
+        Returns:
+            httpx.Response with status_code == 200.
+
+        Raises:
+            ProviderError: If no keys are configured or all keys are exhausted.
+        """
+        if not self._keys:
+            raise ProviderError(
+                message="No OpenRouter API keys configured",
+                provider=ProviderType.OPENROUTER,
+                retryable=False,
+            )
+
+        last_response: httpx.Response | None = None
+        last_exc: Exception | None = None
+
+        for key in self._keys:
+            fingerprint = f"...{key[-8:]}" if len(key) >= 8 else "???"
+            try:
+                response = await self.client.post(
+                    endpoint,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {key}"},
+                )
+                if response.status_code == 200:
+                    return response
+                elif response.status_code in _RETRIABLE_AUTH_STATUSES:
+                    logger.warning(
+                        "OpenRouter key %s returned HTTP %d, trying next key",
+                        fingerprint,
+                        response.status_code,
+                    )
+                    last_response = response
+                    continue
+                else:
+                    # Non-retriable status (e.g. 400 bad model) — return as-is
+                    # so the caller can raise the appropriate error.
+                    return response
+            except httpx.TimeoutException as e:
+                logger.warning(
+                    "OpenRouter key %s timed out, trying next key",
+                    fingerprint,
+                )
+                last_exc = e
+                continue
+            except httpx.HTTPError as e:
+                logger.warning(
+                    "OpenRouter key %s network error: %s, trying next key",
+                    fingerprint,
+                    e,
+                )
+                last_exc = e
+                continue
+
+        # All keys exhausted
+        logger.error(
+            "OpenRouter: all %d key(s) exhausted — no successful response",
+            len(self._keys),
+        )
+        if last_exc is not None:
+            raise ProviderError(
+                message=str(last_exc),
+                provider=ProviderType.OPENROUTER,
+                retryable=True,
+            ) from last_exc
+        if last_response is not None:
+            self._handle_error(last_response)  # always raises
+        raise ProviderError(
+            message="All OpenRouter keys exhausted with no response",
+            provider=ProviderType.OPENROUTER,
+            retryable=False,
+        )
+
     async def list_models(self, capability: str | None = None) -> list[OpenRouterModel]:
         """List available models from OpenRouter.
 
@@ -183,7 +309,11 @@ class OpenRouterProvider(LLMProvider):
             >>> for model in models[:5]:
             ...     print(f"{model.id}: {model.context_length} tokens")
         """
-        response = await self.client.get("/models")
+        key = self._keys[0] if self._keys else ""
+        response = await self.client.get(
+            "/models",
+            headers={"Authorization": f"Bearer {key}"} if key else {},
+        )
 
         if response.status_code != 200:
             self._handle_error(response)
@@ -209,7 +339,9 @@ class OpenRouterProvider(LLMProvider):
     ) -> LLMResponse[T] | LLMResponse[str]:
         """Generate text with optional structured output.
 
-        Uses OpenRouter's chat/completions API.
+        Uses OpenRouter's chat/completions API. When multiple API keys are
+        configured, automatically falls back to the next key on 401/402/429
+        or network/timeout errors.
 
         Args:
             prompt: The input prompt.
@@ -302,7 +434,7 @@ class OpenRouterProvider(LLMProvider):
                 messages.insert(0, {"role": "system", "content": schema_message})
 
         try:
-            response = await self.client.post("/chat/completions", json=payload)
+            response = await self._post_with_key_fallback("/chat/completions", payload)
 
             if response.status_code != 200:
                 self._handle_error(response)
@@ -366,6 +498,8 @@ class OpenRouterProvider(LLMProvider):
                 metadata=response_metadata,
             )
 
+        except ProviderError:
+            raise
         except httpx.HTTPError as e:
             logger.error(f"OpenRouter HTTP error: {e}")
             raise ProviderError(
@@ -420,7 +554,7 @@ class OpenRouterProvider(LLMProvider):
         }
 
         try:
-            response = await self.client.post("/chat/completions", json=payload)
+            response = await self._post_with_key_fallback("/chat/completions", payload)
 
             if response.status_code != 200:
                 self._handle_error(response)
@@ -479,6 +613,8 @@ class OpenRouterProvider(LLMProvider):
                 latency_ms=latency_ms,
             )
 
+        except ProviderError:
+            raise
         except httpx.HTTPError as e:
             logger.error(f"OpenRouter image generation error: {e}")
             raise ProviderError(
@@ -548,7 +684,7 @@ class OpenRouterProvider(LLMProvider):
         }
 
         try:
-            response = await self.client.post("/chat/completions", json=payload)
+            response = await self._post_with_key_fallback("/chat/completions", payload)
 
             if response.status_code != 200:
                 self._handle_error(response)
@@ -582,6 +718,8 @@ class OpenRouterProvider(LLMProvider):
                 latency_ms=latency_ms,
             )
 
+        except ProviderError:
+            raise
         except httpx.HTTPError as e:
             logger.error(f"OpenRouter vision error: {e}")
             raise ProviderError(
@@ -599,8 +737,12 @@ class OpenRouterProvider(LLMProvider):
             bool: True if provider is healthy.
         """
         try:
+            key = self._keys[0] if self._keys else ""
             # Just check models endpoint - doesn't require completion tokens
-            response = await self.client.get("/models")
+            response = await self.client.get(
+                "/models",
+                headers={"Authorization": f"Bearer {key}"} if key else {},
+            )
             return response.status_code == 200
         except Exception as e:
             logger.warning(f"OpenRouter health check failed: {e}")

--- a/app/eval/runner.py
+++ b/app/eval/runner.py
@@ -112,7 +112,7 @@ class ModelEvaluator:
             logger.info("Initialized Google provider for eval")
 
         if settings.has_provider(ProviderType.OPENROUTER):
-            self.openrouter_provider = OpenRouterProvider(api_key=settings.OPENROUTER_API_KEY)
+            self.openrouter_provider = OpenRouterProvider(api_keys=settings.openrouter_keys)
             logger.info("Initialized OpenRouter provider for eval")
 
     def _get_provider(self, provider_name: str):

--- a/app/main.py
+++ b/app/main.py
@@ -108,11 +108,12 @@ async def lifespan(app: FastAPI):
             logger.error(f"Blob storage initialization failed: {e}")
 
     # Initialize OpenRouter model registry for dynamic fallback selection
-    if _settings.OPENROUTER_API_KEY:
+    _openrouter_keys = _settings.openrouter_keys
+    if _openrouter_keys:
         from app.core.model_registry import OpenRouterModelRegistry
 
         registry = OpenRouterModelRegistry.get_instance()
-        await registry.initialize(api_key=_settings.OPENROUTER_API_KEY)
+        await registry.initialize(api_key=_openrouter_keys[0])
         registry.start_background_refresh(interval=3600)
 
     # Start the MCP Streamable HTTP session manager so the /mcp sub-app

--- a/tests/unit/test_openrouter_multikey.py
+++ b/tests/unit/test_openrouter_multikey.py
@@ -1,0 +1,349 @@
+"""Unit tests for OpenRouter multi-key fallback in providers/openrouter.py.
+
+Tests the _post_with_key_fallback helper and the call_text / generate_image /
+analyze_image callers using httpx.MockTransport so no real network calls are made.
+
+Matrix:
+    - empty key list   → ProviderError (no keys configured)
+    - single key, 200  → returns response
+    - first 401, second 200 → logs WARN, returns second response
+    - all 401          → logs ERROR, raises (AuthenticationError via _handle_error)
+    - non-retriable 400 → raises immediately without trying next key
+
+Run with:
+    pytest tests/unit/test_openrouter_multikey.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+
+from app.core.providers.base import AuthenticationError, ProviderError
+from app.core.providers.openrouter import OpenRouterProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _chat_response(content: str = "hello") -> dict[str, Any]:
+    """Minimal OpenRouter /chat/completions success payload."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "content": content,
+                    "role": "assistant",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+    }
+
+
+def _error_response(status: int, message: str = "error") -> dict[str, Any]:
+    return {"error": {"message": message, "code": status}}
+
+
+class _SequenceTransport(httpx.AsyncBaseTransport):
+    """Return a pre-defined sequence of responses for POST /chat/completions."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses: Iterator[httpx.Response] = iter(responses)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        try:
+            return next(self._responses)
+        except StopIteration:
+            pytest.fail(f"Unexpected extra request to {request.url}")
+
+
+def _make_response(status: int, body: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps(body).encode(),
+    )
+
+
+def _make_provider_with_transport(
+    keys: list[str],
+    transport: httpx.BaseTransport,
+) -> OpenRouterProvider:
+    """Build an OpenRouterProvider whose client uses the given MockTransport."""
+    provider = OpenRouterProvider(api_keys=keys, base_url="https://openrouter.ai/api/v1")
+    # Inject a client wired to the fake transport
+    provider._client = httpx.AsyncClient(
+        base_url="https://openrouter.ai/api/v1",
+        transport=transport,
+        headers={
+            "HTTP-Referer": "https://timepoint.ai",
+            "X-Title": "TIMEPOINT Flash",
+            "Content-Type": "application/json",
+        },
+    )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# config.py — openrouter_keys property
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+class TestOpenrouterKeysProperty:
+    """Test Settings.openrouter_keys parsing logic."""
+
+    def test_plural_wins_over_singular(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEY="singular",
+            OPENROUTER_API_KEYS="key1,key2,key3",
+        )
+        assert s.openrouter_keys == ["key1", "key2", "key3"]
+
+    def test_falls_back_to_singular(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEY="only-key",
+            OPENROUTER_API_KEYS=None,
+        )
+        assert s.openrouter_keys == ["only-key"]
+
+    def test_empty_plural_falls_back_to_singular(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEY="fallback",
+            OPENROUTER_API_KEYS="  ,  ,  ",  # all whitespace/commas
+        )
+        assert s.openrouter_keys == ["fallback"]
+
+    def test_deduplication(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEYS="key1,key2,key1,key3",
+        )
+        assert s.openrouter_keys == ["key1", "key2", "key3"]
+
+    def test_strips_whitespace(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEYS=" key1 , key2 , key3 ",
+        )
+        assert s.openrouter_keys == ["key1", "key2", "key3"]
+
+    def test_empty_returns_empty_list(self):
+        from app.config import Settings
+
+        s = Settings(
+            OPENROUTER_API_KEY=None,
+            OPENROUTER_API_KEYS=None,
+        )
+        assert s.openrouter_keys == []
+
+    def test_has_provider_openrouter_uses_keys_list(self):
+        from app.config import ProviderType, Settings
+
+        # Has provider when plural key is set but singular is None
+        s = Settings(
+            OPENROUTER_API_KEY=None,
+            OPENROUTER_API_KEYS="key1,key2",
+        )
+        assert s.has_provider(ProviderType.OPENROUTER) is True
+
+    def test_has_provider_openrouter_false_when_no_keys(self):
+        from app.config import ProviderType, Settings
+
+        s = Settings(
+            OPENROUTER_API_KEY=None,
+            OPENROUTER_API_KEYS=None,
+        )
+        assert s.has_provider(ProviderType.OPENROUTER) is False
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterProvider init
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+class TestOpenRouterProviderInit:
+    """Test OpenRouterProvider initialisation with various key inputs."""
+
+    def test_single_api_key(self):
+        p = OpenRouterProvider(api_key="sk-single")
+        assert p._keys == ["sk-single"]
+        assert p.api_key == "sk-single"
+
+    def test_api_keys_list(self):
+        p = OpenRouterProvider(api_keys=["sk-a", "sk-b", "sk-c"])
+        assert p._keys == ["sk-a", "sk-b", "sk-c"]
+
+    def test_api_keys_wins_over_api_key(self):
+        p = OpenRouterProvider(api_key="sk-old", api_keys=["sk-new"])
+        assert p._keys == ["sk-new"]
+
+    def test_empty_strings_filtered(self):
+        p = OpenRouterProvider(api_keys=["sk-a", "", "sk-b"])
+        assert p._keys == ["sk-a", "sk-b"]
+
+    def test_no_keys(self):
+        p = OpenRouterProvider()
+        assert p._keys == []
+
+
+# ---------------------------------------------------------------------------
+# _post_with_key_fallback — core iteration logic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+class TestPostWithKeyFallback:
+    """Test the internal key-iteration helper via call_text."""
+
+    async def test_no_keys_raises(self):
+        """Empty key list → ProviderError immediately."""
+        provider = OpenRouterProvider(api_keys=[])
+        with pytest.raises(ProviderError, match="No OpenRouter API keys configured"):
+            await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+
+    async def test_single_key_200(self):
+        """Single key with 200 → returns response."""
+        transport = _SequenceTransport([
+            _make_response(200, _chat_response("ok")),
+        ])
+        provider = _make_provider_with_transport(["sk-key1"], transport)
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+        assert resp.status_code == 200
+
+    async def test_first_401_second_200(self):
+        """First key returns 401, second key returns 200 → success."""
+        transport = _SequenceTransport([
+            _make_response(401, _error_response(401, "User not found")),
+            _make_response(200, _chat_response("hi")),
+        ])
+        provider = _make_provider_with_transport(["sk-dead", "sk-live"], transport)
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["message"]["content"] == "hi"
+
+    async def test_first_402_second_200(self):
+        """402 (insufficient credits) is also retriable."""
+        transport = _SequenceTransport([
+            _make_response(402, _error_response(402, "Insufficient credits")),
+            _make_response(200, _chat_response("paid")),
+        ])
+        provider = _make_provider_with_transport(["sk-broke", "sk-rich"], transport)
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+        assert resp.status_code == 200
+
+    async def test_first_429_second_200(self):
+        """429 (rate limit) is retriable — next key attempted."""
+        transport = _SequenceTransport([
+            _make_response(429, _error_response(429, "Rate limited")),
+            _make_response(200, _chat_response("ok")),
+        ])
+        provider = _make_provider_with_transport(["sk-limited", "sk-free"], transport)
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+        assert resp.status_code == 200
+
+    async def test_all_401_raises(self):
+        """All keys return 401 → logs ERROR and raises AuthenticationError."""
+        transport = _SequenceTransport([
+            _make_response(401, _error_response(401, "bad key")),
+            _make_response(401, _error_response(401, "bad key")),
+        ])
+        provider = _make_provider_with_transport(["sk-a", "sk-b"], transport)
+        with pytest.raises((AuthenticationError, ProviderError)):
+            await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+
+    async def test_non_retriable_400_raises_immediately(self):
+        """400 (bad model / bad request) → returned immediately, no next key tried."""
+        # If the second response were consumed the SequenceTransport would fail
+        transport = _SequenceTransport([
+            _make_response(400, _error_response(400, "model not found")),
+            # This response must NOT be consumed:
+            _make_response(200, _chat_response("should_not_reach")),
+        ])
+        provider = _make_provider_with_transport(["sk-key1", "sk-key2"], transport)
+        # _post_with_key_fallback returns non-retriable responses for caller to handle
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "bad-model"})
+        assert resp.status_code == 400
+
+    async def test_timeout_triggers_next_key(self):
+        """Network timeout on first key → try second key."""
+
+        class TimeoutThenOkTransport(httpx.AsyncBaseTransport):
+            def __init__(self) -> None:
+                self._call_count = 0
+
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                self._call_count += 1
+                if self._call_count == 1:
+                    raise httpx.TimeoutException("timed out", request=request)
+                return _make_response(200, _chat_response("recovered"))
+
+        transport = TimeoutThenOkTransport()
+        provider = _make_provider_with_transport(["sk-slow", "sk-fast"], transport)
+        resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# call_text end-to-end through fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+class TestCallTextMultiKey:
+    """Test call_text with multi-key fallback via MockTransport."""
+
+    async def test_call_text_single_key_200(self):
+        """Basic call_text with one key succeeds."""
+        transport = _SequenceTransport([
+            _make_response(200, _chat_response("the answer")),
+        ])
+        provider = _make_provider_with_transport(["sk-only"], transport)
+        response = await provider.call_text(prompt="What is 2+2?", model="test/model")
+        assert response.content == "the answer"
+
+    async def test_call_text_first_401_second_200(self):
+        """call_text falls back to second key after first returns 401."""
+        transport = _SequenceTransport([
+            _make_response(401, _error_response(401, "revoked")),
+            _make_response(200, _chat_response("fallback answer")),
+        ])
+        provider = _make_provider_with_transport(["sk-revoked", "sk-valid"], transport)
+        response = await provider.call_text(prompt="Test", model="test/model")
+        assert response.content == "fallback answer"
+
+    async def test_call_text_all_401_raises(self):
+        """call_text raises when all keys are invalid."""
+        transport = _SequenceTransport([
+            _make_response(401, _error_response(401, "bad")),
+            _make_response(401, _error_response(401, "also bad")),
+            _make_response(401, _error_response(401, "all bad")),
+        ])
+        provider = _make_provider_with_transport(
+            ["sk-a", "sk-b", "sk-c"], transport
+        )
+        with pytest.raises((AuthenticationError, ProviderError)):
+            await provider.call_text(prompt="Test", model="test/model")
+
+    async def test_call_text_non_retriable_400_raises(self):
+        """call_text raises immediately on 400 without trying next key."""
+        transport = _SequenceTransport([
+            _make_response(400, _error_response(400, "invalid model")),
+        ])
+        provider = _make_provider_with_transport(["sk-key"], transport)
+        with pytest.raises(ProviderError):
+            await provider.call_text(prompt="Test", model="invalid/model")

--- a/tests/unit/test_openrouter_multikey.py
+++ b/tests/unit/test_openrouter_multikey.py
@@ -26,10 +26,10 @@ import pytest
 from app.core.providers.base import AuthenticationError, ProviderError
 from app.core.providers.openrouter import OpenRouterProvider
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _chat_response(content: str = "hello") -> dict[str, Any]:
     """Minimal OpenRouter /chat/completions success payload."""
@@ -94,6 +94,7 @@ def _make_provider_with_transport(
 # ---------------------------------------------------------------------------
 # config.py — openrouter_keys property
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.fast
 class TestOpenrouterKeysProperty:
@@ -175,6 +176,7 @@ class TestOpenrouterKeysProperty:
 # OpenRouterProvider init
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.fast
 class TestOpenRouterProviderInit:
     """Test OpenRouterProvider initialisation with various key inputs."""
@@ -205,6 +207,7 @@ class TestOpenRouterProviderInit:
 # _post_with_key_fallback — core iteration logic
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.fast
 @pytest.mark.asyncio
 class TestPostWithKeyFallback:
@@ -218,19 +221,23 @@ class TestPostWithKeyFallback:
 
     async def test_single_key_200(self):
         """Single key with 200 → returns response."""
-        transport = _SequenceTransport([
-            _make_response(200, _chat_response("ok")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(200, _chat_response("ok")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-key1"], transport)
         resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
         assert resp.status_code == 200
 
     async def test_first_401_second_200(self):
         """First key returns 401, second key returns 200 → success."""
-        transport = _SequenceTransport([
-            _make_response(401, _error_response(401, "User not found")),
-            _make_response(200, _chat_response("hi")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(401, _error_response(401, "User not found")),
+                _make_response(200, _chat_response("hi")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-dead", "sk-live"], transport)
         resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
         assert resp.status_code == 200
@@ -238,30 +245,36 @@ class TestPostWithKeyFallback:
 
     async def test_first_402_second_200(self):
         """402 (insufficient credits) is also retriable."""
-        transport = _SequenceTransport([
-            _make_response(402, _error_response(402, "Insufficient credits")),
-            _make_response(200, _chat_response("paid")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(402, _error_response(402, "Insufficient credits")),
+                _make_response(200, _chat_response("paid")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-broke", "sk-rich"], transport)
         resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
         assert resp.status_code == 200
 
     async def test_first_429_second_200(self):
         """429 (rate limit) is retriable — next key attempted."""
-        transport = _SequenceTransport([
-            _make_response(429, _error_response(429, "Rate limited")),
-            _make_response(200, _chat_response("ok")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(429, _error_response(429, "Rate limited")),
+                _make_response(200, _chat_response("ok")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-limited", "sk-free"], transport)
         resp = await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
         assert resp.status_code == 200
 
     async def test_all_401_raises(self):
         """All keys return 401 → logs ERROR and raises AuthenticationError."""
-        transport = _SequenceTransport([
-            _make_response(401, _error_response(401, "bad key")),
-            _make_response(401, _error_response(401, "bad key")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(401, _error_response(401, "bad key")),
+                _make_response(401, _error_response(401, "bad key")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-a", "sk-b"], transport)
         with pytest.raises((AuthenticationError, ProviderError)):
             await provider._post_with_key_fallback("/chat/completions", {"model": "x"})
@@ -269,11 +282,13 @@ class TestPostWithKeyFallback:
     async def test_non_retriable_400_raises_immediately(self):
         """400 (bad model / bad request) → returned immediately, no next key tried."""
         # If the second response were consumed the SequenceTransport would fail
-        transport = _SequenceTransport([
-            _make_response(400, _error_response(400, "model not found")),
-            # This response must NOT be consumed:
-            _make_response(200, _chat_response("should_not_reach")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(400, _error_response(400, "model not found")),
+                # This response must NOT be consumed:
+                _make_response(200, _chat_response("should_not_reach")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-key1", "sk-key2"], transport)
         # _post_with_key_fallback returns non-retriable responses for caller to handle
         resp = await provider._post_with_key_fallback("/chat/completions", {"model": "bad-model"})
@@ -302,6 +317,7 @@ class TestPostWithKeyFallback:
 # call_text end-to-end through fallback
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.fast
 @pytest.mark.asyncio
 class TestCallTextMultiKey:
@@ -309,41 +325,47 @@ class TestCallTextMultiKey:
 
     async def test_call_text_single_key_200(self):
         """Basic call_text with one key succeeds."""
-        transport = _SequenceTransport([
-            _make_response(200, _chat_response("the answer")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(200, _chat_response("the answer")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-only"], transport)
         response = await provider.call_text(prompt="What is 2+2?", model="test/model")
         assert response.content == "the answer"
 
     async def test_call_text_first_401_second_200(self):
         """call_text falls back to second key after first returns 401."""
-        transport = _SequenceTransport([
-            _make_response(401, _error_response(401, "revoked")),
-            _make_response(200, _chat_response("fallback answer")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(401, _error_response(401, "revoked")),
+                _make_response(200, _chat_response("fallback answer")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-revoked", "sk-valid"], transport)
         response = await provider.call_text(prompt="Test", model="test/model")
         assert response.content == "fallback answer"
 
     async def test_call_text_all_401_raises(self):
         """call_text raises when all keys are invalid."""
-        transport = _SequenceTransport([
-            _make_response(401, _error_response(401, "bad")),
-            _make_response(401, _error_response(401, "also bad")),
-            _make_response(401, _error_response(401, "all bad")),
-        ])
-        provider = _make_provider_with_transport(
-            ["sk-a", "sk-b", "sk-c"], transport
+        transport = _SequenceTransport(
+            [
+                _make_response(401, _error_response(401, "bad")),
+                _make_response(401, _error_response(401, "also bad")),
+                _make_response(401, _error_response(401, "all bad")),
+            ]
         )
+        provider = _make_provider_with_transport(["sk-a", "sk-b", "sk-c"], transport)
         with pytest.raises((AuthenticationError, ProviderError)):
             await provider.call_text(prompt="Test", model="test/model")
 
     async def test_call_text_non_retriable_400_raises(self):
         """call_text raises immediately on 400 without trying next key."""
-        transport = _SequenceTransport([
-            _make_response(400, _error_response(400, "invalid model")),
-        ])
+        transport = _SequenceTransport(
+            [
+                _make_response(400, _error_response(400, "invalid model")),
+            ]
+        )
         provider = _make_provider_with_transport(["sk-key"], transport)
         with pytest.raises(ProviderError):
             await provider.call_text(prompt="Test", model="invalid/model")


### PR DESCRIPTION
## Summary

Wires up the existing `OPENROUTER_API_KEYS` Railway env var (currently dead-ended — no code reads it). Adds a per-request key-iteration fallback chain to the OpenRouter provider so a single revoked/exhausted/rate-limited key no longer blocks generation.

Companion to the marketing-x sibling task — semantics intentionally kept parallel for ease of future maintenance.

## Changes

- **`app/config.py`** — adds `OPENROUTER_API_KEYS` field (comma-separated plural) plus an `openrouter_keys` property that prefers the plural, falls back to the singular `OPENROUTER_API_KEY`, de-duplicates, and strips empties. `has_provider` / `get_api_key` / `detected_provider` / `has_any_provider` updated to consult the parsed list.
- **`app/core/providers/openrouter.py`** — new `_post_with_key_fallback` helper iterates `self._keys` on HTTP 401/402/429 or network/timeout errors, logging WARN with the last-8-char key fingerprint before advancing. On 200 it returns immediately; on a non-retriable status (e.g. 400 invalid model) it returns the response so the caller can raise via `_handle_error`. On exhaustion it logs ERROR and re-raises the last error. `call_text`, `generate_image`, and `analyze_image` now route through this helper instead of calling `self.client.post` directly. The Authorization header was moved from client-level to per-request so each key can be tried without re-creating the httpx client. `OpenRouterProvider.__init__` gains an `api_keys: list[str]` param (plural wins over `api_key` singular; backward-compatible).
- **`app/core/llm_router.py`** / **`app/eval/runner.py`** — pass `api_keys=settings.openrouter_keys` when constructing the provider; log key count at startup.
- **`app/main.py`** — registry init now uses `openrouter_keys[0]` (first key), guarded by truthiness of the list.
- **`tests/unit/test_openrouter_multikey.py`** — 25 new unit tests covering the parsing matrix (plural-wins, singular-fallback, empty-plural, dedup, whitespace, empty), provider init variants, and `_post_with_key_fallback` / `call_text` scenarios (empty list, single 200, first-401-second-200, first-402, first-429, all-401, non-retriable 400, timeout-then-ok). Uses `httpx.MockTransport` — no real network calls.

## Backward compatibility

Existing `OPENROUTER_API_KEY` (singular) deployments continue to work unchanged. `openrouter_keys` returns a single-element list when only the singular var is set. No call sites needed to be updated beyond the LLMRouter / eval runner construction sites.

## Deploy-private (`timepoint-flash-deploy-private-feb-2026`)

Per `SYNC.md` in the private repo, the public→private direction is a periodic `git fetch upstream && git merge upstream/main`. Verified the private repo's overlay list does NOT include `app/config.py`, `app/core/providers/openrouter.py`, `app/core/llm_router.py`, `app/eval/runner.py`, or `app/main.py` — so these changes will merge cleanly when the private repo is next synced. No private-side changes required. Spot-checked private `app/config.py` for any plural `OPENROUTER_API_KEYS` handling — none exists, so no merge conflicts expected.

## Deployment notes (for human operator)

- Railway project `timepoint-flash-deploy-private-f` (project ID `055080c9-dd8a-48f1-802b-71f4be7b409b`), env `production`, service `timepoint-flash-deploy-private-feb-2026` already has `OPENROUTER_API_KEYS` set — but the value is the **dead 10-key chain** documented in `project_openrouter_keys.md`. Replace the value with fresh keys after this PR merges + private repo syncs.
- The singular `OPENROUTER_API_KEY` continues to function as a single-key fallback if `OPENROUTER_API_KEYS` is unset.

## Test plan

- [x] `pytest tests/unit/test_openrouter_multikey.py` — 25/25 PASSED locally
- [x] `pytest tests/unit/test_providers.py tests/unit/test_config.py` — all PASSED locally (no regressions in touched code paths)
- [ ] CI: fast unit tests green
- [ ] CI: e2e (non-slow) green
- [ ] CI: code quality green
- [ ] Post-merge: manual sanity check of an existing `providers/openrouter.py` call path against production with current singular-key Railway config (proves back-compat)

## Documentation

- `el-4simf` (Flash Model Config audit) — already updated to reference the new `OPENROUTER_API_KEYS` env var.
- `el-36pvy` (post-mortem) — to receive a "Permanent multi-key fallback" note after merge.