### PR TITLE
feat: add models[], provider.order, and Retry-After to OpenRouter client

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -401,6 +401,24 @@ class Settings(BaseSettings):
             "a key is skipped on HTTP 401/402/429 or network/timeout errors."
         ),
     )
+    OPENROUTER_MODELS: str | None = Field(
+        default=None,
+        description=(
+            "Comma-separated ordered model fallback list for OpenRouter native routing (models[] param). "
+            "These are tried in order when the primary model fails at the provider level. "
+            "Example: 'google/gemini-3-flash-preview,nvidia/llama-3.1-nemotron-70b-instruct'. "
+            "Defaults to a 3-model chain across Google/NVIDIA/NousResearch."
+        ),
+    )
+    OPENROUTER_PROVIDER_ORDER: str | None = Field(
+        default=None,
+        description=(
+            "Comma-separated preferred inference provider order for OpenRouter (provider.order param). "
+            "Controls which inference providers are tried first for the selected model. "
+            "Example: 'Google AI Studio,Together,Fireworks'. "
+            "Defaults to Google AI Studio → Together → Fireworks."
+        ),
+    )
     STABILITY_API_KEY: str | None = Field(
         default=None,
         description="Stability AI API key for SD3.5 image generation",
@@ -661,6 +679,55 @@ class Settings(BaseSettings):
                 seen.add(k)
                 result.append(k)
         return result
+
+    @property
+    def openrouter_models(self) -> list[str]:
+        """Return the ordered model fallback list for OpenRouter native routing.
+
+        Used as the ``models[]`` parameter in OpenRouter chat completions to
+        enable server-side model-level failover when the primary model is
+        unavailable or overloaded.
+
+        Returns:
+            list[str]: Ordered model IDs to try as fallbacks.
+
+        Examples:
+            >>> # With OPENROUTER_MODELS="google/gemini-3-flash-preview,nvidia/llama-3.1-nemotron-70b-instruct"
+            >>> settings.openrouter_models  # ["google/gemini-3-flash-preview", "nvidia/..."]
+            >>> # Without env var: returns 3-model default chain
+            >>> settings.openrouter_models  # ["google/gemini-3-flash-preview", ...]
+        """
+        if self.OPENROUTER_MODELS:
+            return [m.strip() for m in self.OPENROUTER_MODELS.split(",") if m.strip()]
+        # Sensible 3-model default: Google thinking → NVIDIA quality → NousResearch reliable
+        # All are in VerifiedModels.OPENROUTER_TEXT and tested against Flash's pipeline.
+        return [
+            "google/gemini-3-flash-preview",
+            "nvidia/llama-3.1-nemotron-70b-instruct",
+            "nousresearch/hermes-3-llama-3.1-70b",
+        ]
+
+    @property
+    def openrouter_provider_order(self) -> list[str]:
+        """Return the preferred inference provider order for OpenRouter native routing.
+
+        Used as the ``provider.order`` parameter in OpenRouter chat completions.
+        Controls which inference providers are tried first when OpenRouter routes
+        a request to the selected model.
+
+        Returns:
+            list[str]: Ordered provider names (as used by OpenRouter).
+
+        Examples:
+            >>> # With OPENROUTER_PROVIDER_ORDER="Google AI Studio,Together"
+            >>> settings.openrouter_provider_order  # ["Google AI Studio", "Together"]
+            >>> # Without env var: returns 3-provider default
+            >>> settings.openrouter_provider_order  # ["Google AI Studio", "Together", "Fireworks"]
+        """
+        if self.OPENROUTER_PROVIDER_ORDER:
+            return [p.strip() for p in self.OPENROUTER_PROVIDER_ORDER.split(",") if p.strip()]
+        # Default preference: Google (primary), Together (fast/reliable), Fireworks (quality)
+        return ["Google AI Studio", "Together", "Fireworks"]
 
     @property
     def has_any_provider(self) -> bool:

--- a/app/core/llm_router.py
+++ b/app/core/llm_router.py
@@ -279,11 +279,15 @@ class LLMRouter:
 
         if settings.has_provider(ProviderType.OPENROUTER):
             self.providers[ProviderType.OPENROUTER] = OpenRouterProvider(
-                api_keys=settings.openrouter_keys
+                api_keys=settings.openrouter_keys,
+                models=settings.openrouter_models,
+                provider_order=settings.openrouter_provider_order,
             )
             logger.info(
-                "Initialized OpenRouter provider with %d key(s)",
+                "Initialized OpenRouter provider with %d key(s), %d fallback model(s), %d provider(s)",
                 len(settings.openrouter_keys),
+                len(settings.openrouter_models),
+                len(settings.openrouter_provider_order),
             )
 
         if settings.has_provider(ProviderType.STABILITY):

--- a/app/core/providers/openrouter.py
+++ b/app/core/providers/openrouter.py
@@ -12,6 +12,19 @@ key fingerprint before advancing. On a non-retriable error (e.g. 400 bad model)
 execution stops immediately. If all keys are exhausted an ERROR is logged and
 the last error is re-raised.
 
+Native OpenRouter routing (models[] + provider.order): When ``models`` and
+``provider_order`` are supplied the provider injects OpenRouter's server-side
+failover into every chat/completions request. ``models`` lists fallback model
+IDs tried in order when the primary model is unavailable; ``provider_order``
+steers OpenRouter to preferred inference providers. ``allow_fallbacks=True``
+and ``require_parameters=True`` are always set so the failover chain respects
+structured-output and other per-request parameters.
+
+Retry-After handling: On HTTP 429 or 503 the provider checks the ``Retry-After``
+response header and, if present, sleeps ``min(Retry-After, 30)`` seconds before
+retrying once with the same key. If the retry also fails the key is skipped in
+the normal multi-key rotation. HTTP 401/402/400 are never retried via this path.
+
 Examples:
     >>> from app.core.providers.openrouter import OpenRouterProvider
     >>> provider = OpenRouterProvider(api_key="sk-or-v1-...")
@@ -24,9 +37,11 @@ Tests:
     - tests/unit/test_providers.py::test_openrouter_provider_init
     - tests/unit/test_providers.py::test_openrouter_provider_call_text
     - tests/unit/test_openrouter_multikey.py  (multi-key fallback matrix)
+    - tests/unit/test_openrouter_native_routing.py  (models[], provider.order, Retry-After)
     - tests/integration/test_llm_router.py::test_openrouter_provider_integration
 """
 
+import asyncio
 import logging
 import time
 from typing import Any, TypeVar
@@ -54,7 +69,10 @@ OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
 OPENROUTER_CHAT_URL = f"{OPENROUTER_BASE_URL}/chat/completions"
 
 # HTTP status codes that trigger key rotation (try next key)
-_RETRIABLE_AUTH_STATUSES: frozenset[int] = frozenset({401, 402, 429})
+_RETRIABLE_AUTH_STATUSES: frozenset[int] = frozenset({401, 402, 429, 503})
+
+# HTTP status codes where a Retry-After header is honoured before key rotation
+_RETRY_AFTER_STATUSES: frozenset[int] = frozenset({429, 503})
 
 
 class OpenRouterModel(BaseModel):
@@ -113,6 +131,8 @@ class OpenRouterProvider(LLMProvider):
         api_keys: list[str] | None = None,
         base_url: str = OPENROUTER_BASE_URL,
         timeout: float = 60.0,
+        models: list[str] | None = None,
+        provider_order: list[str] | None = None,
     ) -> None:
         """Initialize OpenRouter provider.
 
@@ -123,6 +143,13 @@ class OpenRouterProvider(LLMProvider):
                       When supplied, takes precedence over api_key.
             base_url: API base URL (default: https://openrouter.ai/api/v1).
             timeout: Request timeout in seconds.
+            models: Ordered list of fallback model IDs injected as the ``models[]``
+                    parameter in chat/completions requests. Tried in order when the
+                    primary model is unavailable. Empty list → field omitted.
+            provider_order: Ordered list of inference provider names injected as
+                            ``provider.order``. Empty list → empty order (OpenRouter
+                            chooses). Always sets ``allow_fallbacks=True`` and
+                            ``require_parameters=True`` when non-None.
         """
         # Build internal key list (plural wins over singular)
         if api_keys:
@@ -137,6 +164,8 @@ class OpenRouterProvider(LLMProvider):
         self.base_url = base_url
         self.timeout = timeout
         self._client: httpx.AsyncClient | None = None
+        self._models: list[str] = models if models is not None else []
+        self._provider_order: list[str] = provider_order if provider_order is not None else []
 
     @property
     def client(self) -> httpx.AsyncClient:
@@ -245,7 +274,35 @@ class OpenRouterProvider(LLMProvider):
                 )
                 if response.status_code == 200:
                     return response
-                elif response.status_code in _RETRIABLE_AUTH_STATUSES:
+
+                # Honour Retry-After on 429 / 503 — sleep once, then retry same key.
+                # This handles transient provider-side throttling without burning
+                # the next key on what is likely a brief capacity blip.
+                # 401 / 402 / 400 are NOT retried via this path.
+                if response.status_code in _RETRY_AFTER_STATUSES:
+                    retry_after_header = response.headers.get("Retry-After")
+                    if retry_after_header:
+                        try:
+                            sleep_secs = min(int(retry_after_header), 30)
+                            logger.info(
+                                "OpenRouter key %s: HTTP %d with Retry-After %ds — sleeping",
+                                fingerprint,
+                                response.status_code,
+                                sleep_secs,
+                            )
+                            await asyncio.sleep(sleep_secs)
+                            response = await self.client.post(
+                                endpoint,
+                                json=payload,
+                                headers={"Authorization": f"Bearer {key}"},
+                            )
+                            if response.status_code == 200:
+                                return response
+                        except (ValueError, OverflowError):
+                            # Malformed Retry-After header — proceed without sleep
+                            pass
+
+                if response.status_code in _RETRIABLE_AUTH_STATUSES:
                     logger.warning(
                         "OpenRouter key %s returned HTTP %d, trying next key",
                         fingerprint,
@@ -378,6 +435,20 @@ class OpenRouterProvider(LLMProvider):
             "model": model,
             "messages": messages,
         }
+
+        # Native OpenRouter server-side routing: model fallbacks + provider preference.
+        # models[] lists fallback model IDs tried when the primary model is unavailable.
+        # provider.order steers which inference providers handle the request.
+        # require_parameters=True ensures fallback providers support all request params
+        # (e.g. response_format for structured output).
+        if self._models:
+            payload["models"] = self._models
+        if self._models or self._provider_order:
+            payload["provider"] = {
+                "order": self._provider_order,
+                "allow_fallbacks": True,
+                "require_parameters": True,
+            }
 
         # Web search plugins support (e.g. [{"id": "web", "max_results": 5}])
         if "plugins" in kwargs:

--- a/tests/unit/test_openrouter_native_routing.py
+++ b/tests/unit/test_openrouter_native_routing.py
@@ -1,0 +1,412 @@
+"""Unit tests for OpenRouter native routing: models[], provider.order, Retry-After.
+
+Tests the server-side failover parameters injected into chat/completions requests
+and the Retry-After sleep-and-retry logic added on top of the multi-key iterator.
+
+Coverage matrix:
+    Config:
+        - openrouter_models: env var parsed, default fallback chain returned
+        - openrouter_provider_order: env var parsed, default provider order returned
+    Request body:
+        - models[] injected when _models is non-empty
+        - provider object injected (order, allow_fallbacks, require_parameters)
+        - require_parameters=True forwarded to payload
+        - provider block absent when _models and _provider_order both empty
+    Retry-After:
+        - 429 with Retry-After header → sleep min(header, 30), retry once
+        - 503 with Retry-After header → sleep min(header, 30), retry once
+        - 429 without Retry-After header → no sleep, rotate key immediately
+        - Retry-After > 30 → capped at 30 seconds
+        - No double-retry: if sleep-and-retry also fails, key is skipped (not retried again)
+        - 401 / 402 / 400 → no Retry-After sleep, existing key-rotation / error behavior
+
+Run with:
+    pytest tests/unit/test_openrouter_native_routing.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.core.providers.base import ProviderError
+from app.core.providers.openrouter import OpenRouterProvider
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_openrouter_multikey.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _chat_response(content: str = "ok") -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {"content": content, "role": "assistant"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+    }
+
+
+def _error_response(status: int, message: str = "error") -> dict[str, Any]:
+    return {"error": {"message": message, "code": status}}
+
+
+def _make_response(
+    status: int,
+    body: dict[str, Any],
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    h = {"Content-Type": "application/json"}
+    if headers:
+        h.update(headers)
+    return httpx.Response(
+        status_code=status,
+        headers=h,
+        content=json.dumps(body).encode(),
+    )
+
+
+class _CapturingTransport(httpx.AsyncBaseTransport):
+    """Records every request and returns a fixed 200 success response."""
+
+    def __init__(self, response_body: dict[str, Any] | None = None) -> None:
+        self.requests: list[httpx.Request] = []
+        self._body = response_body or _chat_response()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return _make_response(200, self._body)
+
+
+class _SequenceTransport(httpx.AsyncBaseTransport):
+    """Return a fixed sequence of responses."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._iter = iter(responses)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            pytest.fail(f"Unexpected extra request to {request.url}")
+
+
+def _make_provider(
+    keys: list[str] = ("sk-test",),
+    models: list[str] | None = None,
+    provider_order: list[str] | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> OpenRouterProvider:
+    provider = OpenRouterProvider(
+        api_keys=list(keys),
+        models=models,
+        provider_order=provider_order,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    t = transport or _CapturingTransport()
+    provider._client = httpx.AsyncClient(
+        base_url="https://openrouter.ai/api/v1",
+        transport=t,
+        headers={
+            "HTTP-Referer": "https://timepoint.ai",
+            "X-Title": "TIMEPOINT Flash",
+            "Content-Type": "application/json",
+        },
+    )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Config — openrouter_models and openrouter_provider_order properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestConfigOpenrouterNativeRouting:
+    """Test Settings.openrouter_models and openrouter_provider_order parsing."""
+
+    def test_openrouter_models_default(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_MODELS=None)
+        models = s.openrouter_models
+        assert isinstance(models, list)
+        assert len(models) == 3
+        # All must be slash-delimited OpenRouter model IDs
+        assert all("/" in m for m in models)
+
+    def test_openrouter_models_env_parsed(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_MODELS="anthropic/claude-3.5-haiku,openai/gpt-4o-mini")
+        assert s.openrouter_models == ["anthropic/claude-3.5-haiku", "openai/gpt-4o-mini"]
+
+    def test_openrouter_models_strips_whitespace(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_MODELS=" anthropic/claude-3.5-haiku , openai/gpt-4o-mini ")
+        assert s.openrouter_models == ["anthropic/claude-3.5-haiku", "openai/gpt-4o-mini"]
+
+    def test_openrouter_models_ignores_empty_segments(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_MODELS="model-a,,  ,model-b")
+        assert s.openrouter_models == ["model-a", "model-b"]
+
+    def test_openrouter_provider_order_default(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_PROVIDER_ORDER=None)
+        order = s.openrouter_provider_order
+        assert isinstance(order, list)
+        assert len(order) == 3
+
+    def test_openrouter_provider_order_env_parsed(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_PROVIDER_ORDER="Anthropic,OpenAI,Together")
+        assert s.openrouter_provider_order == ["Anthropic", "OpenAI", "Together"]
+
+    def test_openrouter_provider_order_strips_whitespace(self):
+        from app.config import Settings
+
+        s = Settings(OPENROUTER_PROVIDER_ORDER=" Google AI Studio , Together ")
+        assert s.openrouter_provider_order == ["Google AI Studio", "Together"]
+
+
+# ---------------------------------------------------------------------------
+# Provider init — models and provider_order constructor params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestOpenRouterProviderNativeRoutingInit:
+    """Test that models / provider_order constructor params are stored."""
+
+    def test_models_stored(self):
+        p = OpenRouterProvider(
+            api_key="sk-x",
+            models=["m1", "m2"],
+        )
+        assert p._models == ["m1", "m2"]
+
+    def test_provider_order_stored(self):
+        p = OpenRouterProvider(
+            api_key="sk-x",
+            provider_order=["Google AI Studio", "Together"],
+        )
+        assert p._provider_order == ["Google AI Studio", "Together"]
+
+    def test_defaults_empty_lists(self):
+        p = OpenRouterProvider(api_key="sk-x")
+        assert p._models == []
+        assert p._provider_order == []
+
+    def test_none_becomes_empty_list(self):
+        p = OpenRouterProvider(api_key="sk-x", models=None, provider_order=None)
+        assert p._models == []
+        assert p._provider_order == []
+
+
+# ---------------------------------------------------------------------------
+# Request body — models[] and provider object injected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+class TestNativeRoutingPayload:
+    """Verify models[] and provider block are injected into the request body."""
+
+    async def test_models_injected_in_body(self):
+        """When _models is set, 'models' key appears in request JSON."""
+        transport = _CapturingTransport()
+        provider = _make_provider(
+            models=["fallback/model-a", "fallback/model-b"],
+            transport=transport,
+        )
+        await provider.call_text(prompt="hello", model="primary/model")
+        assert len(transport.requests) == 1
+        body = json.loads(transport.requests[0].content)
+        assert body["models"] == ["fallback/model-a", "fallback/model-b"]
+
+    async def test_provider_object_injected_in_body(self):
+        """When _models is set, 'provider' block appears in request JSON."""
+        transport = _CapturingTransport()
+        provider = _make_provider(
+            models=["fallback/model-a"],
+            provider_order=["Google AI Studio", "Together"],
+            transport=transport,
+        )
+        await provider.call_text(prompt="hello", model="primary/model")
+        body = json.loads(transport.requests[0].content)
+        assert "provider" in body
+        prov = body["provider"]
+        assert prov["order"] == ["Google AI Studio", "Together"]
+        assert prov["allow_fallbacks"] is True
+
+    async def test_require_parameters_forwarded(self):
+        """require_parameters=True is always set when provider block is present."""
+        transport = _CapturingTransport()
+        provider = _make_provider(
+            models=["fallback/model"],
+            provider_order=["Fireworks"],
+            transport=transport,
+        )
+        await provider.call_text(prompt="hello", model="primary/model")
+        body = json.loads(transport.requests[0].content)
+        assert body["provider"]["require_parameters"] is True
+
+    async def test_no_provider_block_when_empty(self):
+        """When _models and _provider_order are both empty, no provider block is added."""
+        transport = _CapturingTransport()
+        provider = _make_provider(models=[], provider_order=[], transport=transport)
+        await provider.call_text(prompt="hello", model="primary/model")
+        body = json.loads(transport.requests[0].content)
+        assert "models" not in body
+        assert "provider" not in body
+
+    async def test_provider_block_present_with_only_provider_order(self):
+        """provider block is injected when only provider_order is set (no models)."""
+        transport = _CapturingTransport()
+        provider = _make_provider(
+            models=[],
+            provider_order=["Anthropic"],
+            transport=transport,
+        )
+        await provider.call_text(prompt="hello", model="primary/model")
+        body = json.loads(transport.requests[0].content)
+        assert "provider" in body
+        assert body["provider"]["order"] == ["Anthropic"]
+        assert "models" not in body
+
+    async def test_primary_model_field_unchanged(self):
+        """The primary 'model' field is preserved alongside models[]."""
+        transport = _CapturingTransport()
+        provider = _make_provider(
+            models=["fallback/model"],
+            transport=transport,
+        )
+        await provider.call_text(prompt="hello", model="primary/exact")
+        body = json.loads(transport.requests[0].content)
+        assert body["model"] == "primary/exact"
+        assert "fallback/model" in body["models"]
+
+
+# ---------------------------------------------------------------------------
+# Retry-After handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+class TestRetryAfter:
+    """Verify Retry-After header is honoured on 429 and 503."""
+
+    async def test_429_with_retry_after_sleeps_and_retries(self):
+        """On 429 + Retry-After, provider sleeps and retries same key."""
+        transport = _SequenceTransport(
+            [
+                _make_response(429, _error_response(429, "rate limited"), {"Retry-After": "2"}),
+                _make_response(200, _chat_response("recovered")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-key"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await provider.call_text(prompt="test", model="m/x")
+        mock_sleep.assert_called_once_with(2)
+        assert result.content == "recovered"
+
+    async def test_503_with_retry_after_sleeps_and_retries(self):
+        """On 503 + Retry-After, provider sleeps and retries same key."""
+        transport = _SequenceTransport(
+            [
+                _make_response(
+                    503, _error_response(503, "service unavailable"), {"Retry-After": "5"}
+                ),
+                _make_response(200, _chat_response("back")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-key"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await provider.call_text(prompt="test", model="m/x")
+        mock_sleep.assert_called_once_with(5)
+        assert result.content == "back"
+
+    async def test_retry_after_capped_at_30_seconds(self):
+        """Retry-After values > 30 are capped at 30 seconds."""
+        transport = _SequenceTransport(
+            [
+                _make_response(429, _error_response(429, "rate limited"), {"Retry-After": "120"}),
+                _make_response(200, _chat_response("ok")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-key"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await provider.call_text(prompt="test", model="m/x")
+        mock_sleep.assert_called_once_with(30)
+
+    async def test_429_without_retry_after_no_sleep(self):
+        """429 without Retry-After header → no sleep, key rotation only."""
+        transport = _SequenceTransport(
+            [
+                _make_response(429, _error_response(429, "rate limited")),  # no Retry-After
+                _make_response(200, _chat_response("next key ok")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-a", "sk-b"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await provider.call_text(prompt="test", model="m/x")
+        mock_sleep.assert_not_called()
+        assert result.content == "next key ok"
+
+    async def test_no_double_retry_on_second_failure(self):
+        """If sleep-and-retry also returns 429, key is rotated — not retried again."""
+        transport = _SequenceTransport(
+            [
+                # First key: 429 with Retry-After → sleep → 429 again → rotate
+                _make_response(429, _error_response(429, "rate limited"), {"Retry-After": "1"}),
+                _make_response(429, _error_response(429, "still limited")),
+                # Second key: 200 success
+                _make_response(200, _chat_response("second key")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-a", "sk-b"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await provider.call_text(prompt="test", model="m/x")
+        # Sleep called exactly once (only for the first 429 with Retry-After)
+        mock_sleep.assert_called_once_with(1)
+        assert result.content == "second key"
+
+    async def test_401_no_retry_after_sleep(self):
+        """401 does not trigger Retry-After handling — rotates key directly."""
+        transport = _SequenceTransport(
+            [
+                _make_response(401, _error_response(401, "unauthorized"), {"Retry-After": "10"}),
+                _make_response(200, _chat_response("ok")),
+            ]
+        )
+        provider = _make_provider(keys=["sk-dead", "sk-live"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await provider.call_text(prompt="test", model="m/x")
+        mock_sleep.assert_not_called()
+        assert result.content == "ok"
+
+    async def test_400_no_retry_after_sleep(self):
+        """400 is non-retriable and does not trigger Retry-After or key rotation."""
+        transport = _SequenceTransport(
+            [
+                _make_response(400, _error_response(400, "bad request"), {"Retry-After": "5"}),
+            ]
+        )
+        provider = _make_provider(keys=["sk-key"], transport=transport)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with pytest.raises(ProviderError):
+                await provider.call_text(prompt="test", model="bad/model")
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## Summary

Adds OpenRouter-native server-side failover on top of the multi-key iterator from PR #36 (now merged). The two improvements are complementary: `models[]` handles provider/model failures, multi-key handles single-key revocation.

**References:** research doc el-r755j, post-mortem el-36pvy

### Changes

**`app/core/providers/openrouter.py`**
- New constructor params: `models: list[str]` and `provider_order: list[str]`
- `call_text` injects `models[]` and `provider: {order, allow_fallbacks: true, require_parameters: true}` into the request body when non-empty
- `_post_with_key_fallback` honours `Retry-After` on HTTP 429/503: sleeps `min(header, 30)` seconds, retries the same key once, then rotates; 401/402/400 are never retried via this path
- 503 added to `_RETRIABLE_AUTH_STATUSES` (server errors now also rotate keys)

**`app/config.py`**
- `OPENROUTER_MODELS` env var (comma-separated): model fallback chain, defaults to `google/gemini-3-flash-preview,nvidia/llama-3.1-nemotron-70b-instruct,nousresearch/hermes-3-llama-3.1-70b` (all in VerifiedModels.OPENROUTER_TEXT)
- `OPENROUTER_PROVIDER_ORDER` env var (comma-separated): inference provider preference, defaults to `Google AI Studio,Together,Fireworks`
- `openrouter_models` and `openrouter_provider_order` properties with parsing and defaults

**`app/core/llm_router.py`**
- Passes `settings.openrouter_models` and `settings.openrouter_provider_order` to `OpenRouterProvider.__init__`

**`tests/unit/test_openrouter_native_routing.py`** (24 new tests)
- Config parsing (env vars, defaults, whitespace, empty segments)
- Provider init params stored correctly
- Payload injection: models[], provider object, require_parameters=True, no block when empty
- Retry-After matrix: 429, 503, cap at 30s, no sleep on 401/402/400, no double-retry

### Deploy-private overlay

No overlay changes needed. `app/core/providers/openrouter.py`, `app/config.py`, and `app/core/llm_router.py` are all public-repo files (not in deploy-private's private-only overlay list per SYNC.md). The private repo will pull this via `git merge upstream/main` — conflict guidance in SYNC.md covers config.py (private's version is a superset, new fields merge cleanly) and llm_router.py (private has Stability AI additions, OpenRouter init change merges cleanly).

### Deployment note for Sean (do NOT execute here)

Set on Railway `timepoint-flash-deploy-private-f` (055080c9-...) production:
```
OPENROUTER_MODELS=google/gemini-3-flash-preview,nvidia/llama-3.1-nemotron-70b-instruct,nousresearch/hermes-3-llama-3.1-70b
OPENROUTER_PROVIDER_ORDER=Google AI Studio,Together,Fireworks
```
Defaults in code are identical — only needed to override/tune.