### PR TITLE
fix(models): retire anthropic/claude-3.5-sonnet (no longer available on OpenRouter)

### DIFF
--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -122,8 +122,8 @@ def get_configured_models() -> list[ModelInfo]:
         models.extend(
             [
                 ModelInfo(
-                    id="anthropic/claude-3.5-sonnet",
-                    name="Claude 3.5 Sonnet",
+                    id="anthropic/claude-sonnet-4.5",
+                    name="Claude Sonnet 4.5",
                     provider="openrouter",
                     capabilities=["text", "vision"],
                     context_length=200000,
@@ -465,7 +465,7 @@ async def get_providers() -> ProvidersResponse:
             provider="openrouter",
             available=openrouter_available,
             models_count=300 if openrouter_available else 0,  # Approximate
-            default_text_model="anthropic/claude-3.5-sonnet" if openrouter_available else None,
+            default_text_model="anthropic/claude-sonnet-4.5" if openrouter_available else None,
             default_image_model=settings.IMAGE_MODEL if openrouter_available else None,
         )
     )

--- a/app/core/model_capabilities.py
+++ b/app/core/model_capabilities.py
@@ -399,8 +399,8 @@ TEXT_MODEL_REGISTRY: dict[str, TextModelConfig] = {
         max_output_tokens=8192,
         notes="2.5 Flash via OpenRouter",
     ),
-    "anthropic/claude-3.5-sonnet": TextModelConfig(
-        model_id="anthropic/claude-3.5-sonnet",
+    "anthropic/claude-sonnet-4.5": TextModelConfig(
+        model_id="anthropic/claude-sonnet-4.5",
         provider="openrouter",
         supports_json_schema=False,
         supports_json_mode=True,
@@ -408,7 +408,7 @@ TEXT_MODEL_REGISTRY: dict[str, TextModelConfig] = {
         supports_streaming=True,
         supports_extended_thinking=False,
         max_output_tokens=8192,
-        notes="Claude 3.5 Sonnet via OpenRouter",
+        notes="Claude Sonnet 4.5 via OpenRouter (claude-3.5-sonnet was retired by Anthropic)",
     ),
     "openai/gpt-4o": TextModelConfig(
         model_id="openai/gpt-4o",


### PR DESCRIPTION
## Summary
Anthropic retired `claude-3.5-sonnet` and OpenRouter no longer has endpoints for it (production logs: 'No endpoints found for anthropic/claude-3.5-sonnet' 404). Replaces with the current generation `anthropic/claude-sonnet-4.5`.

Files touched:
- `app/api/v1/models.py` — public catalog ModelInfo + ProviderStatus.default_text_model
- `app/core/model_capabilities.py` — TextModelConfig key + model_id

Docstrings/example references in `app/core/providers/openrouter.py` left as-is (illustrative; not runtime).

## Why
Steward (el-5kaq) flagged in PR #39 verification that production cache-hit checks couldn't run because of these 404s. Discovered via `GET /api/v1/models` against the timepointai OpenRouter account: only `claude-sonnet-4`, `claude-sonnet-4.5`, `claude-sonnet-4.6` are now available in the sonnet line.

## Refs
- Steward verification report: PR #39 comment
- Plan: el-27fs