### PR TITLE
feat(openrouter): pin provider.order=Anthropic for anthropic/* models (cache activation)

### DIFF
--- a/app/core/providers/openrouter.py
+++ b/app/core/providers/openrouter.py
@@ -35,6 +35,14 @@ providers (OpenAI, Gemini, DeepSeek, Grok, Groq, Moonshot) OpenRouter caches
 automatically when the static prefix is byte-identical across requests; no
 markers are needed, so the existing plain-string system message is kept as-is.
 
+To make the Anthropic cache fire, the request must actually reach Anthropic's
+native API — only that backend honours ``cache_control``.  OpenRouter normally
+spreads Anthropic-model traffic across mirror providers (Amazon Bedrock,
+Google Vertex, etc.) that silently strip the marker, so for any
+``anthropic/`` model the provider pins ``provider.order`` to start with
+``"Anthropic"`` (preserving the rest of the configured order as failover).
+Non-Anthropic models keep the configured order unchanged.
+
 Cache hit metrics are extracted from ``usage.prompt_tokens_details.cached_tokens``
 and ``usage.cache_discount`` in every response and logged at INFO so operators
 can confirm savings in production.
@@ -107,6 +115,11 @@ _RETRY_AFTER_STATUSES: frozenset[int] = frozenset({429, 503})
 #
 _EXPLICIT_CACHE_PROVIDER_PREFIXES: tuple[str, ...] = ("anthropic/",)
 
+# OpenRouter's canonical name for Anthropic's native inference backend. Only
+# this backend honours ``cache_control: {type: ephemeral}`` — mirror providers
+# (Amazon Bedrock, Google Vertex, etc.) silently strip it.
+_ANTHROPIC_NATIVE_PROVIDER: str = "Anthropic"
+
 
 def _model_needs_explicit_cache_control(model: str) -> bool:
     """Return True if this model ID requires explicit cache_control markers.
@@ -170,6 +183,56 @@ def _apply_prompt_cache_control(
                 continue
         result.append(msg)
     return result
+
+
+def _resolve_provider_order_for_model(
+    base_order: list[str],
+    model: str,
+) -> list[str]:
+    """Return the provider.order list to use for a request to *model*.
+
+    For Anthropic models (``anthropic/`` prefix) this guarantees that
+    ``"Anthropic"`` is the first entry in the returned list so OpenRouter
+    routes the call to Anthropic's native API — the only backend that
+    honours ``cache_control: {type: ephemeral}`` and therefore the only one
+    that activates the prompt cache.  The configured ``base_order`` is kept
+    as failover behind ``"Anthropic"`` (and de-duplicated if it already
+    contained that name in any position).
+
+    For all other models the ``base_order`` is returned verbatim.
+
+    Args:
+        base_order: The configured provider order (may be empty).
+        model: The OpenRouter model ID (e.g. ``anthropic/claude-3.5-sonnet``).
+
+    Returns:
+        The provider order to send in the ``provider.order`` payload field.
+
+    Examples:
+        >>> _resolve_provider_order_for_model([], "anthropic/claude-3.5-sonnet")
+        ['Anthropic']
+        >>> _resolve_provider_order_for_model(
+        ...     ["Google AI Studio", "Together"],
+        ...     "anthropic/claude-3.5-haiku",
+        ... )
+        ['Anthropic', 'Google AI Studio', 'Together']
+        >>> _resolve_provider_order_for_model(
+        ...     ["Anthropic", "Together"],
+        ...     "anthropic/claude-3.5-haiku",
+        ... )
+        ['Anthropic', 'Together']
+        >>> _resolve_provider_order_for_model(
+        ...     ["Google AI Studio", "Together"],
+        ...     "openai/gpt-4o",
+        ... )
+        ['Google AI Studio', 'Together']
+    """
+    if not _model_needs_explicit_cache_control(model):
+        return list(base_order)
+    if base_order and base_order[0] == _ANTHROPIC_NATIVE_PROVIDER:
+        return list(base_order)
+    rest = [p for p in base_order if p != _ANTHROPIC_NATIVE_PROVIDER]
+    return [_ANTHROPIC_NATIVE_PROVIDER, *rest]
 
 
 def _log_cache_usage(usage: dict[str, Any], model: str, agent: str = "") -> None:
@@ -581,11 +644,21 @@ class OpenRouterProvider(LLMProvider):
         # provider.order steers which inference providers handle the request.
         # require_parameters=True ensures fallback providers support all request params
         # (e.g. response_format for structured output).
+        #
+        # For Anthropic models we always pin "Anthropic" to the front of
+        # provider.order so OpenRouter routes to Anthropic's native API — the
+        # only backend that honours the cache_control markers we inject below.
+        # Without this pin OpenRouter may dispatch the request to Bedrock /
+        # Vertex mirrors that silently strip cache_control, leaving the cache
+        # cold even on identical repeat prompts.
+        resolved_provider_order = _resolve_provider_order_for_model(
+            self._provider_order, model
+        )
         if self._models:
             payload["models"] = self._models
-        if self._models or self._provider_order:
+        if self._models or resolved_provider_order:
             payload["provider"] = {
-                "order": self._provider_order,
+                "order": resolved_provider_order,
                 "allow_fallbacks": True,
                 "require_parameters": True,
             }

--- a/app/core/providers/openrouter.py
+++ b/app/core/providers/openrouter.py
@@ -651,9 +651,7 @@ class OpenRouterProvider(LLMProvider):
         # Without this pin OpenRouter may dispatch the request to Bedrock /
         # Vertex mirrors that silently strip cache_control, leaving the cache
         # cold even on identical repeat prompts.
-        resolved_provider_order = _resolve_provider_order_for_model(
-            self._provider_order, model
-        )
+        resolved_provider_order = _resolve_provider_order_for_model(self._provider_order, model)
         if self._models:
             payload["models"] = self._models
         if self._models or resolved_provider_order:

--- a/tests/unit/test_openrouter_prompt_caching.py
+++ b/tests/unit/test_openrouter_prompt_caching.py
@@ -31,6 +31,7 @@ from app.core.providers.openrouter import (
     _apply_prompt_cache_control,
     _log_cache_usage,
     _model_needs_explicit_cache_control,
+    _resolve_provider_order_for_model,
 )
 
 # ---------------------------------------------------------------------------
@@ -359,3 +360,212 @@ class TestCallTextCacheControl:
             model="anthropic/claude-3.5-sonnet",
         )
         assert response.content == "answer"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_provider_order_for_model — Anthropic pinning
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProviderOrderForModel:
+    """Verify provider.order pinning for Anthropic models so cache_control fires."""
+
+    def test_anthropic_with_empty_base_returns_anthropic_only(self) -> None:
+        result = _resolve_provider_order_for_model([], "anthropic/claude-3.5-sonnet")
+        assert result == ["Anthropic"]
+
+    def test_anthropic_prepends_anthropic_to_base(self) -> None:
+        result = _resolve_provider_order_for_model(
+            ["Google AI Studio", "Together"],
+            "anthropic/claude-3.5-haiku",
+        )
+        assert result == ["Anthropic", "Google AI Studio", "Together"]
+
+    def test_anthropic_already_first_unchanged(self) -> None:
+        result = _resolve_provider_order_for_model(
+            ["Anthropic", "Together"],
+            "anthropic/claude-3.5-haiku",
+        )
+        assert result == ["Anthropic", "Together"]
+
+    def test_anthropic_dedupes_when_in_middle(self) -> None:
+        """If 'Anthropic' is already present (not first), it's moved to the front."""
+        result = _resolve_provider_order_for_model(
+            ["Together", "Anthropic", "Fireworks"],
+            "anthropic/claude-3.5-sonnet",
+        )
+        assert result == ["Anthropic", "Together", "Fireworks"]
+
+    def test_non_anthropic_returns_base_unchanged(self) -> None:
+        base = ["Google AI Studio", "Together", "Fireworks"]
+        result = _resolve_provider_order_for_model(base, "openai/gpt-4o")
+        assert result == base
+
+    def test_non_anthropic_empty_stays_empty(self) -> None:
+        result = _resolve_provider_order_for_model([], "openai/gpt-4o")
+        assert result == []
+
+    def test_returns_new_list_not_alias(self) -> None:
+        """The returned list must not be the same object as base_order."""
+        base = ["A", "B"]
+        result = _resolve_provider_order_for_model(base, "openai/gpt-4o")
+        assert result == base
+        assert result is not base
+
+
+# ---------------------------------------------------------------------------
+# call_text integration: provider.order pinning for Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestCallTextProviderOrderForAnthropic:
+    @pytest.mark.asyncio
+    async def test_anthropic_pins_anthropic_first_when_no_base_order(self) -> None:
+        """Anthropic model with no configured provider_order → provider.order=['Anthropic']."""
+        captured: list[dict[str, Any]] = []
+
+        class _CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                captured.append(body)
+                return httpx.Response(200, json=_chat_response("ok"))
+
+        provider = OpenRouterProvider(api_key="sk-or-v1-testkey")
+        provider._client = httpx.AsyncClient(
+            transport=_CapturingTransport(),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        await provider.call_text(
+            prompt="hi",
+            model="anthropic/claude-3.5-sonnet",
+            system="You are helpful.",
+        )
+
+        assert captured
+        body = captured[0]
+        assert "provider" in body, "provider block should be injected for Anthropic"
+        assert body["provider"]["order"] == ["Anthropic"]
+        assert body["provider"]["allow_fallbacks"] is True
+        assert body["provider"]["require_parameters"] is True
+
+    @pytest.mark.asyncio
+    async def test_anthropic_prepends_anthropic_to_configured_order(self) -> None:
+        """Configured provider_order is preserved as failover behind 'Anthropic'."""
+        captured: list[dict[str, Any]] = []
+
+        class _CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                captured.append(body)
+                return httpx.Response(200, json=_chat_response("ok"))
+
+        provider = OpenRouterProvider(
+            api_key="sk-or-v1-testkey",
+            provider_order=["Google AI Studio", "Together", "Fireworks"],
+        )
+        provider._client = httpx.AsyncClient(
+            transport=_CapturingTransport(),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        await provider.call_text(
+            prompt="hi",
+            model="anthropic/claude-3-haiku",
+            system="System.",
+        )
+
+        assert captured
+        body = captured[0]
+        assert body["provider"]["order"] == [
+            "Anthropic",
+            "Google AI Studio",
+            "Together",
+            "Fireworks",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_non_anthropic_provider_order_unchanged(self) -> None:
+        """Non-Anthropic models keep the configured provider.order verbatim."""
+        captured: list[dict[str, Any]] = []
+
+        class _CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                captured.append(body)
+                return httpx.Response(200, json=_chat_response("ok"))
+
+        provider = OpenRouterProvider(
+            api_key="sk-or-v1-testkey",
+            provider_order=["Google AI Studio", "Together", "Fireworks"],
+        )
+        provider._client = httpx.AsyncClient(
+            transport=_CapturingTransport(),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        await provider.call_text(
+            prompt="hi",
+            model="openai/gpt-4o",
+            system="System.",
+        )
+
+        assert captured
+        body = captured[0]
+        assert body["provider"]["order"] == ["Google AI Studio", "Together", "Fireworks"]
+
+    @pytest.mark.asyncio
+    async def test_non_anthropic_no_config_no_provider_block(self) -> None:
+        """Non-Anthropic with no configured order/models → no provider block (unchanged)."""
+        captured: list[dict[str, Any]] = []
+
+        class _CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                captured.append(body)
+                return httpx.Response(200, json=_chat_response("ok"))
+
+        provider = OpenRouterProvider(api_key="sk-or-v1-testkey")
+        provider._client = httpx.AsyncClient(
+            transport=_CapturingTransport(),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        await provider.call_text(prompt="hi", model="openai/gpt-4o")
+
+        assert captured
+        body = captured[0]
+        assert "provider" not in body
+        assert "models" not in body
+
+    @pytest.mark.asyncio
+    async def test_anthropic_with_models_keeps_models_and_pins_provider(self) -> None:
+        """When fallback models[] is configured, provider.order is still pinned for Anthropic."""
+        captured: list[dict[str, Any]] = []
+
+        class _CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                captured.append(body)
+                return httpx.Response(200, json=_chat_response("ok"))
+
+        provider = OpenRouterProvider(
+            api_key="sk-or-v1-testkey",
+            models=["anthropic/claude-3-haiku", "openai/gpt-4o-mini"],
+            provider_order=["Together"],
+        )
+        provider._client = httpx.AsyncClient(
+            transport=_CapturingTransport(),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        await provider.call_text(
+            prompt="hi",
+            model="anthropic/claude-3.5-sonnet",
+            system="System.",
+        )
+
+        assert captured
+        body = captured[0]
+        assert body["models"] == ["anthropic/claude-3-haiku", "openai/gpt-4o-mini"]
+        assert body["provider"]["order"] == ["Anthropic", "Together"]


### PR DESCRIPTION
## Summary
Per worker el-3oa7's verification on PR #39 (live cache test): cache_control markers were being stripped because OpenRouter routed anthropic/claude-3.5-haiku through **Amazon Bedrock** (2048-token min cache threshold), not direct Anthropic (~1024 min). Flash's longest agent prompt is 1637 tokens — between the two thresholds — so cached_tokens always read 0 in production.

This PR pins \`provider.order=['Anthropic', ...configured]\` for anthropic/* models so OpenRouter routes to Anthropic's native API where cache_control actually fires.

Direct test (worker el-3oa7): 99.4% cache hit rate (1201/1208 tokens cached), 89.5% cost savings per cached call.

## Tests
- 33/33 prompt-caching tests (21 existing + 12 new) — all pass
- 73/73 OpenRouter tests — all pass
- 651/651 full unit sweep — all pass (1 pre-existing mcp ModuleNotFoundError unrelated)

## Refs
- Director task: el-1f0xy
- Verification: PR #39 comment by el-3oa7
- Research: el-r755j
- Plan: el-27fs (final task)