### PR TITLE
fix: align CREDIT_COSTS with Gateway (parity for /credits/costs)

### DIFF
--- a/app/auth/credits.py
+++ b/app/auth/credits.py
@@ -15,9 +15,13 @@ from app.models_auth import CreditAccount, CreditTransaction, TransactionType
 
 logger = logging.getLogger(__name__)
 
-# Credit costs per operation — kept in sync with Gateway's cost table so
-# ``/credits/costs`` returns the same payload regardless of which service
-# answers the request.
+# Credit costs per operation — MUST stay in sync with the Gateway's
+# ``CREDIT_COSTS`` (gateway/auth_core/credits.py) so ``/credits/costs``
+# returns the same payload regardless of which service answers the
+# request. The Gateway table is authoritative: when adding or removing a
+# cost key, update Gateway first, then mirror the change here. The
+# Playwright contract test ``flash-deep.spec.ts`` (GET /credits/costs via
+# gateway vs direct) asserts the two ``costs`` dicts are identical.
 CREDIT_COSTS: dict[str, int] = {
     # Flash generation
     "generate_balanced": 5,
@@ -31,16 +35,11 @@ CREDIT_COSTS: dict[str, int] = {
     "conductor_base": 5,
     "conductor_generate": 5,
     "conductor_pro_sim": 15,
+    "conductor_pro_capitalization_portfolio": 5,
     "conductor_compare": 10,
     "conductor_campaign_sim": 15,
     "conductor_campaign_survey": 5,
     "conductor_compare_campaigns": 10,
-    # Funding Falcon
-    "falcon_discover": 2,
-    "falcon_pipeline": 10,
-    "falcon_simulate": 5,
-    "falcon_export": 1,
-    "falcon_run": 10,
     # SkipMeetings
     "meeting_generation": 1,
     # Clockchain


### PR DESCRIPTION
## Summary
E2E surfaced `tests/api/flash-deep.spec.ts:730` failing on gateway/direct cost-table parity: direct Flash carried `falcon_*` (5 keys) and was missing `conductor_pro_capitalization_portfolio` vs the Gateway-proxied response.

This aligns Flash's CREDIT_COSTS with the Gateway: drops the 5 stale `falcon_*` entries (Falcon was absorbed into web-app on 2026-05-04) and adds `conductor_pro_capitalization_portfolio: 5`. After merge + Railway redeploy, both /credits/costs handlers return byte-equal cost dicts.

E2E fix task: el-1bgr5 (plan el-319p — E2E 2026-05-13 Phase 3 Fixes).

## Test plan
- [ ] Railway flash redeploy completes
- [ ] `curl https://flash.timepointai.com/api/v1/credits/costs` and `curl https://api.timepointai.com/api/v1/credits/costs` return byte-equal `costs` dicts
- [ ] `npx playwright test tests/api/flash-deep.spec.ts:730` passes against prod