### PR TITLE
fix(mcp): resolve Flash user FK + deduct Gateway credits in tp_flash_generate

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -31,8 +31,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import uuid
 from typing import Any
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
@@ -109,6 +112,201 @@ def _validate_enum(
     if normalized not in allowed:
         return None, (f"Invalid {field}={value!r}. Expected one of: {sorted(allowed)}.")
     return normalized, None
+
+
+# ---------------------------------------------------------------------------
+# Gateway-aware user/credit helpers
+# ---------------------------------------------------------------------------
+#
+# The MCP path goes DIRECTLY to flash.timepointai.com/mcp/ — it bypasses the
+# Gateway's metering middleware that normally deducts credits for REST calls
+# proxied through api.timepointai.com.  That means two things the REST path
+# normally handles for us happen here instead:
+#
+# 1. **User provisioning.**  ``BearerAuthMiddleware`` resolves a ``tp_gw_*``
+#    token to the *Gateway*'s ``user_id``.  That UUID is not guaranteed to
+#    exist in Flash's local ``users`` table — and ``timepoints.user_id`` has
+#    a FK to ``users.id``.  Setting ``timepoint.user_id`` to an unknown UUID
+#    blows up with ``ForeignKeyViolationError`` and the tool returns
+#    ``{"error": ...}`` instead of the documented ``{"id", "status", ...}``
+#    shape.  We mirror ``/api/v1/users/resolve`` semantics: look up by id
+#    first, then by ``external_id``, and auto-provision a Flash User row
+#    when neither matches.
+#
+# 2. **Credit deduction.**  The Gateway is the authoritative credit ledger
+#    (see ``project_auth_consolidation.md``).  REST callers get debited by
+#    the metering middleware in front of the Gateway proxy; MCP callers
+#    don't.  We deduct up-front via the Gateway's internal
+#    ``/internal/credits/spend`` endpoint so the same ``tp_gw_*`` key
+#    produces the same balance change regardless of transport.
+
+
+_GATEWAY_GENERATION_COST: int = 5  # mirrors CREDIT_COSTS["generate_balanced"]
+
+
+async def _resolve_or_provision_flash_user(user_id: str) -> str | None:
+    """Return a Flash ``User.id`` for the gateway-resolved ``user_id``.
+
+    Looks up by ``User.id`` first, then ``User.external_id`` (the gateway
+    user_id is stored there by ``/api/v1/users/resolve``).  If neither
+    matches, provisions a fresh Flash User + vestigial CreditAccount,
+    matching the auto-provisioning behaviour of ``resolve_user`` in
+    ``app/api/v1/users.py``.  Returns ``None`` on any error so the caller
+    can fall back to creating an unowned timepoint rather than 500'ing.
+
+    The Flash User's ``apple_sub`` placeholder uses a ``gateway:`` prefix
+    so it can never collide with a real Apple Sign-In subject (those are
+    opaque Apple identifiers, not UUID-shaped).  ``external_id`` is set to
+    the gateway user_id so a subsequent ``/api/v1/users/resolve`` call for
+    the same identity is idempotent.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+
+    from app.database import get_session
+    from app.models_auth import CreditAccount, User
+
+    try:
+        async with get_session() as session:
+            existing = await session.execute(select(User).where(User.id == user_id))
+            user = existing.scalar_one_or_none()
+            if user is None:
+                existing = await session.execute(
+                    select(User).where(User.external_id == user_id)
+                )
+                user = existing.scalar_one_or_none()
+            if user is not None:
+                return user.id
+
+            new_user = User(
+                id=str(uuid.uuid4()),
+                apple_sub=f"gateway:{user_id}",
+                external_id=user_id,
+            )
+            session.add(new_user)
+            try:
+                await session.flush()
+                # Match resolve_user(): every Flash User gets a credit
+                # account row.  The Gateway is the authoritative ledger, so
+                # we seed balance=0 here instead of granting Flash signup
+                # credits a second time.
+                session.add(
+                    CreditAccount(
+                        id=str(uuid.uuid4()),
+                        user_id=new_user.id,
+                        balance=0,
+                        lifetime_earned=0,
+                    )
+                )
+                await session.commit()
+                logger.info("Provisioned Flash user %s for gateway user_id=%s", new_user.id, user_id)
+                return new_user.id
+            except IntegrityError:
+                # Race: a concurrent /resolve or /mcp call won.  Re-look up
+                # by external_id and use whichever row landed.
+                await session.rollback()
+                existing = await session.execute(
+                    select(User).where(User.external_id == user_id)
+                )
+                user = existing.scalar_one_or_none()
+                return user.id if user is not None else None
+    except Exception:
+        logger.exception("Failed to resolve/provision Flash user for gateway id=%s", user_id)
+        return None
+
+
+async def _gateway_credit_op(
+    path: str,
+    payload: dict[str, Any],
+) -> tuple[bool, dict[str, Any] | None]:
+    """POST to a Gateway ``/internal/credits/*`` endpoint.
+
+    Returns ``(ok, body)`` — ``ok`` is True only when the HTTP call returned
+    2xx AND the JSON body has ``success: True``.  ``body`` is the parsed
+    JSON when available so the caller can surface ``error`` strings or
+    ``balance_after``.
+
+    Both ``GATEWAY_INTERNAL_URL`` and ``GATEWAY_SERVICE_KEY`` must be set —
+    when either is missing we return ``(True, None)`` so local dev (no
+    Gateway) doesn't break the MCP tool.  This matches the soft-fail
+    behaviour of ``BearerAuthMiddleware``.
+    """
+    gateway_url = os.environ.get("GATEWAY_INTERNAL_URL", "").rstrip("/")
+    service_key = os.environ.get("GATEWAY_SERVICE_KEY", "")
+    if not gateway_url or not service_key:
+        return True, None
+
+    url = f"{gateway_url}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers={"X-Service-Key": service_key, "Content-Type": "application/json"},
+            )
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("Gateway %s failed (network): %s", path, exc)
+        return False, None
+
+    if response.status_code != 200:
+        logger.warning("Gateway %s returned HTTP %d", path, response.status_code)
+        return False, None
+
+    try:
+        body = response.json()
+    except ValueError:
+        logger.warning("Gateway %s returned non-JSON body", path)
+        return False, None
+
+    if not isinstance(body, dict):
+        return False, None
+    return bool(body.get("success", False)), body
+
+
+async def _gateway_spend_credits(
+    user_id: str, cost: int, description: str
+) -> tuple[bool, str | None]:
+    """Deduct ``cost`` credits from the Gateway's ledger for ``user_id``.
+
+    Returns ``(success, error_message)``.  Success is True both when the
+    Gateway confirms a deduction and when the Gateway is intentionally
+    unconfigured (local dev).  On failure, ``error_message`` carries a
+    short reason suitable for an MCP ``{"error": ...}`` response.
+    """
+    ok, body = await _gateway_credit_op(
+        "/internal/credits/spend",
+        {
+            "user_id": user_id,
+            "cost": cost,
+            "transaction_type": "generation",
+            "description": description,
+        },
+    )
+    if ok:
+        return True, None
+    err = (body or {}).get("error") if isinstance(body, dict) else None
+    return False, err or "Credit deduction failed (gateway unreachable or rejected)"
+
+
+async def _gateway_refund_credits(user_id: str, amount: int, description: str) -> None:
+    """Best-effort refund via the Gateway.  Logged on failure, never raises."""
+    ok, body = await _gateway_credit_op(
+        "/internal/credits/grant",
+        {
+            "user_id": user_id,
+            "amount": amount,
+            "transaction_type": "refund",
+            "description": description,
+        },
+    )
+    if not ok:
+        err = (body or {}).get("error") if isinstance(body, dict) else None
+        logger.critical(
+            "Gateway credit refund FAILED: user=%s amount=%d error=%s",
+            user_id,
+            amount,
+            err,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +424,38 @@ async def tp_flash_generate(
         return {"error": f"Invalid model configuration: {detail}"}
 
     user_id = _current_user()
+    is_authenticated_user = bool(user_id) and user_id != "mcp-anonymous"
+
+    # Deduct credits at the Gateway BEFORE we create any DB rows.  This
+    # matches the REST endpoint semantics (credits charged on submission,
+    # refunded on background failure) and mirrors the metering middleware
+    # behaviour for the proxy path.  Gateway is the authoritative ledger
+    # (see project_auth_consolidation.md); deducting here is what makes
+    # MCP-initiated generations show up on /credits/balance.
+    if is_authenticated_user:
+        spent_ok, spend_err = await _gateway_spend_credits(
+            user_id,
+            cost=_GATEWAY_GENERATION_COST,
+            description=f"mcp:tp_flash_generate ({normalized_preset or 'balanced'}): {query[:60]}",
+        )
+        if not spent_ok:
+            return {"error": spend_err or "Credit deduction failed"}
+
+    # Resolve the gateway user_id into a Flash users.id so the FK
+    # constraint on timepoints.user_id is satisfied.  Auto-provisions a
+    # Flash row when none exists for this identity.
+    flash_user_id: str | None = None
+    if is_authenticated_user:
+        flash_user_id = await _resolve_or_provision_flash_user(user_id)
+        if flash_user_id is None:
+            # Don't strand the caller's credits — refund and surface a
+            # structured error.
+            await _gateway_refund_credits(
+                user_id,
+                _GATEWAY_GENERATION_COST,
+                description=f"mcp:tp_flash_generate user-resolution-failed: {query[:60]}",
+            )
+            return {"error": "Failed to resolve user in Flash database"}
 
     # Create a PROCESSING timepoint row and schedule the pipeline.  We do
     # this in a short-lived session so we don't block the MCP request on
@@ -238,8 +468,11 @@ async def tp_flash_generate(
         query=query,
         status=TimepointStatus.PROCESSING,
     )
-    if user_id and user_id != "mcp-anonymous":
-        timepoint.user_id = user_id
+    if flash_user_id:
+        timepoint.user_id = flash_user_id
+    # Tag the row as MCP-originated so observability dashboards and the
+    # background-task refund path can tell the two transports apart.
+    timepoint.api_source = "mcp"
     if normalized_visibility:
         try:
             timepoint.visibility = TimepointVisibility(normalized_visibility)
@@ -253,6 +486,13 @@ async def tp_flash_generate(
             await session.refresh(timepoint)
     except Exception as exc:
         logger.exception("Failed to create timepoint row for MCP request")
+        # Refund — we already deducted credits at the Gateway above.
+        if is_authenticated_user:
+            await _gateway_refund_credits(
+                user_id,
+                _GATEWAY_GENERATION_COST,
+                description=f"mcp:tp_flash_generate timepoint-create-failed: {query[:60]}",
+            )
         return {"error": f"Failed to create timepoint: {exc}"}
 
     # Fire-and-forget background generation.  We use asyncio.create_task

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -171,9 +171,7 @@ async def _resolve_or_provision_flash_user(user_id: str) -> str | None:
             existing = await session.execute(select(User).where(User.id == user_id))
             user = existing.scalar_one_or_none()
             if user is None:
-                existing = await session.execute(
-                    select(User).where(User.external_id == user_id)
-                )
+                existing = await session.execute(select(User).where(User.external_id == user_id))
                 user = existing.scalar_one_or_none()
             if user is not None:
                 return user.id
@@ -199,15 +197,15 @@ async def _resolve_or_provision_flash_user(user_id: str) -> str | None:
                     )
                 )
                 await session.commit()
-                logger.info("Provisioned Flash user %s for gateway user_id=%s", new_user.id, user_id)
+                logger.info(
+                    "Provisioned Flash user %s for gateway user_id=%s", new_user.id, user_id
+                )
                 return new_user.id
             except IntegrityError:
                 # Race: a concurrent /resolve or /mcp call won.  Re-look up
                 # by external_id and use whichever row landed.
                 await session.rollback()
-                existing = await session.execute(
-                    select(User).where(User.external_id == user_id)
-                )
+                existing = await session.execute(select(User).where(User.external_id == user_id))
                 user = existing.scalar_one_or_none()
                 return user.id if user is not None else None
     except Exception:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -712,9 +712,7 @@ class TestTpFlashGenerateGatewayIntegration:
         assert result["owner_id"] == "gw_user_123"
 
     @pytest.mark.asyncio
-    async def test_mcp_origin_tagged_on_timepoint(
-        self, _stub_generation, tool_callable
-    ):
+    async def test_mcp_origin_tagged_on_timepoint(self, _stub_generation, tool_callable):
         """All MCP-originated timepoints should be tagged api_source='mcp'."""
         token = current_bearer_user.set("user_origin_test")
         try:
@@ -784,9 +782,7 @@ class TestGatewayCreditOp:
 
         monkeypatch.setattr("app.mcp_server.httpx.AsyncClient", FakeClient)
 
-        ok, body = await _gateway_credit_op(
-            "/internal/credits/spend", {"user_id": "u1", "cost": 5}
-        )
+        ok, body = await _gateway_credit_op("/internal/credits/spend", {"user_id": "u1", "cost": 5})
         assert ok is True
         assert body is not None
         assert body["balance_after"] == 95

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -419,7 +419,13 @@ class _FakeSessionCM:
 
 @pytest.fixture
 def _stub_generation(monkeypatch):
-    """Patch DB + pipeline so tp_flash_generate doesn't hit anything real."""
+    """Patch DB + pipeline so tp_flash_generate doesn't hit anything real.
+
+    Also patches the Gateway-side credit/user helpers introduced for the MCP
+    path (see app/mcp_server.py).  Tests that care about Gateway interactions
+    re-patch them; tests that just care about validation, defaults, or shape
+    get pass-through stubs that don't make any network or DB calls.
+    """
     session = _FakeSession()
 
     def fake_get_session():
@@ -448,6 +454,21 @@ def _stub_generation(monkeypatch):
     # The tool imports get_session inside the function body using
     # ``from app.database import get_session``, so patching the attribute on
     # the module is enough.
+
+    # Stub out the Gateway helpers — by default credit-spend succeeds and
+    # the resolver echoes the bearer user_id back as the Flash user id.
+    async def fake_spend(user_id, cost, description):
+        return True, None
+
+    async def fake_refund(user_id, amount, description):
+        return None
+
+    async def fake_resolve(user_id):
+        return user_id
+
+    monkeypatch.setattr("app.mcp_server._gateway_spend_credits", fake_spend)
+    monkeypatch.setattr("app.mcp_server._gateway_refund_credits", fake_refund)
+    monkeypatch.setattr("app.mcp_server._resolve_or_provision_flash_user", fake_resolve)
 
     yield session
 
@@ -556,6 +577,340 @@ class TestTpFlashGenerate:
         """Empty strings for preset/visibility/model_policy should not error."""
         result = await tool_callable(query="rome 50 BCE", preset="", visibility="", model_policy="")
         assert "error" not in result, result
+
+
+# ============================================================================
+# tp_flash_generate — Gateway credit + Flash user resolution paths
+# ============================================================================
+
+
+@pytest.mark.fast
+class TestTpFlashGenerateGatewayIntegration:
+    """Cover the MCP-only behaviours added to fix flash-mcp-roundtrip:134.
+
+    The MCP path bypasses the Gateway's metering middleware, so the tool is
+    responsible for two things the REST proxy normally handles: charging the
+    Gateway credit ledger and resolving the bearer user_id into a Flash
+    ``users.id`` (so the ``timepoints.user_id_fkey`` constraint is satisfied).
+    """
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_triggers_credit_spend(
+        self, _stub_generation, tool_callable, monkeypatch
+    ):
+        calls: list[tuple[str, int, str]] = []
+
+        async def recording_spend(user_id, cost, description):
+            calls.append((user_id, cost, description))
+            return True, None
+
+        monkeypatch.setattr("app.mcp_server._gateway_spend_credits", recording_spend)
+
+        token = current_bearer_user.set("user_abc")
+        try:
+            result = await tool_callable(query="rome 50 BCE")
+        finally:
+            current_bearer_user.reset(token)
+
+        assert "error" not in result, result
+        assert len(calls) == 1
+        spent_user_id, spent_cost, spent_desc = calls[0]
+        assert spent_user_id == "user_abc"
+        assert spent_cost == 5  # CREDIT_COSTS["generate_balanced"]
+        assert "tp_flash_generate" in spent_desc
+
+    @pytest.mark.asyncio
+    async def test_credit_spend_failure_returns_error(
+        self, _stub_generation, tool_callable, monkeypatch
+    ):
+        async def failing_spend(user_id, cost, description):
+            return False, "Insufficient credits: have 0, need 5"
+
+        monkeypatch.setattr("app.mcp_server._gateway_spend_credits", failing_spend)
+
+        token = current_bearer_user.set("user_broke")
+        try:
+            result = await tool_callable(query="rome 50 BCE")
+        finally:
+            current_bearer_user.reset(token)
+
+        assert "error" in result
+        assert "Insufficient credits" in result["error"]
+        # No timepoint was created.
+        assert len(_stub_generation.added) == 0
+
+    @pytest.mark.asyncio
+    async def test_anonymous_caller_skips_credit_spend(
+        self, _stub_generation, tool_callable, monkeypatch
+    ):
+        called = {"flag": False}
+
+        async def recording_spend(user_id, cost, description):
+            called["flag"] = True
+            return True, None
+
+        monkeypatch.setattr("app.mcp_server._gateway_spend_credits", recording_spend)
+
+        # No bearer set → anonymous fallback.
+        result = await tool_callable(query="rome 50 BCE")
+
+        assert "error" not in result, result
+        assert result["owner_id"] == "mcp-anonymous"
+        assert called["flag"] is False
+
+    @pytest.mark.asyncio
+    async def test_user_resolution_failure_refunds_credits(
+        self, _stub_generation, tool_callable, monkeypatch
+    ):
+        refunds: list[tuple[str, int, str]] = []
+
+        async def failing_resolve(user_id):
+            return None
+
+        async def recording_refund(user_id, amount, description):
+            refunds.append((user_id, amount, description))
+
+        monkeypatch.setattr("app.mcp_server._resolve_or_provision_flash_user", failing_resolve)
+        monkeypatch.setattr("app.mcp_server._gateway_refund_credits", recording_refund)
+
+        token = current_bearer_user.set("user_unresolvable")
+        try:
+            result = await tool_callable(query="rome 50 BCE")
+        finally:
+            current_bearer_user.reset(token)
+
+        assert "error" in result
+        assert "resolve user" in result["error"].lower()
+        # Credit was refunded exactly once.
+        assert len(refunds) == 1
+        refunded_user, refunded_amount, _ = refunds[0]
+        assert refunded_user == "user_unresolvable"
+        assert refunded_amount == 5
+
+    @pytest.mark.asyncio
+    async def test_resolved_flash_user_id_assigned_to_timepoint(
+        self, _stub_generation, tool_callable, monkeypatch
+    ):
+        async def resolving(user_id):
+            # Simulate auto-provisioning returning a freshly-minted Flash id.
+            assert user_id == "gw_user_123"
+            return "flash_uuid_456"
+
+        monkeypatch.setattr("app.mcp_server._resolve_or_provision_flash_user", resolving)
+
+        token = current_bearer_user.set("gw_user_123")
+        try:
+            result = await tool_callable(query="rome 50 BCE")
+        finally:
+            current_bearer_user.reset(token)
+
+        assert "error" not in result, result
+        # The Flash user id (not the gateway id) lands on the row.
+        timepoint = _stub_generation.added[0]
+        assert timepoint.user_id == "flash_uuid_456"
+        # But owner_id in the MCP response is the caller-facing gateway id.
+        assert result["owner_id"] == "gw_user_123"
+
+    @pytest.mark.asyncio
+    async def test_mcp_origin_tagged_on_timepoint(
+        self, _stub_generation, tool_callable
+    ):
+        """All MCP-originated timepoints should be tagged api_source='mcp'."""
+        token = current_bearer_user.set("user_origin_test")
+        try:
+            result = await tool_callable(query="rome 50 BCE")
+        finally:
+            current_bearer_user.reset(token)
+
+        assert "error" not in result, result
+        timepoint = _stub_generation.added[0]
+        assert timepoint.api_source == "mcp"
+
+
+# ============================================================================
+# _gateway_credit_op — Gateway HTTP helper
+# ============================================================================
+
+
+@pytest.mark.fast
+class TestGatewayCreditOp:
+    """The shared Gateway HTTP helper underpins both spend and refund.
+
+    Behaviour mirrors ``_verify_via_gateway`` from bearer_auth.py: missing
+    config soft-fails (returns ``(True, None)`` so local dev still works),
+    network/HTTP errors are swallowed and surfaced as ``(False, None)``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_config_returns_ok_none(self, monkeypatch):
+        from app.mcp_server import _gateway_credit_op
+
+        # _reset_state already clears these, but be explicit.
+        monkeypatch.delenv("GATEWAY_INTERNAL_URL", raising=False)
+        monkeypatch.delenv("GATEWAY_SERVICE_KEY", raising=False)
+
+        ok, body = await _gateway_credit_op("/internal/credits/spend", {"user_id": "x"})
+        assert ok is True
+        assert body is None
+
+    @pytest.mark.asyncio
+    async def test_success_response_parsed(self, monkeypatch):
+        from app.mcp_server import _gateway_credit_op
+
+        monkeypatch.setenv("GATEWAY_INTERNAL_URL", "https://gateway.example.com")
+        monkeypatch.setenv("GATEWAY_SERVICE_KEY", "s3cret")
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"success": True, "balance_after": 95, "transaction_id": "txn_1"}
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, url, json, headers):
+                assert url == "https://gateway.example.com/internal/credits/spend"
+                assert headers["X-Service-Key"] == "s3cret"
+                assert json == {"user_id": "u1", "cost": 5}
+                return FakeResponse()
+
+        monkeypatch.setattr("app.mcp_server.httpx.AsyncClient", FakeClient)
+
+        ok, body = await _gateway_credit_op(
+            "/internal/credits/spend", {"user_id": "u1", "cost": 5}
+        )
+        assert ok is True
+        assert body is not None
+        assert body["balance_after"] == 95
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_false(self, monkeypatch):
+        from app.mcp_server import _gateway_credit_op
+
+        monkeypatch.setenv("GATEWAY_INTERNAL_URL", "https://gateway.example.com")
+        monkeypatch.setenv("GATEWAY_SERVICE_KEY", "s3cret")
+
+        class FakeResponse:
+            status_code = 500
+
+            def json(self):
+                return {"detail": "boom"}
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, *a, **kw):
+                return FakeResponse()
+
+        monkeypatch.setattr("app.mcp_server.httpx.AsyncClient", FakeClient)
+        ok, body = await _gateway_credit_op("/internal/credits/spend", {})
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_success_false_in_body_returns_false(self, monkeypatch):
+        from app.mcp_server import _gateway_credit_op
+
+        monkeypatch.setenv("GATEWAY_INTERNAL_URL", "https://gateway.example.com")
+        monkeypatch.setenv("GATEWAY_SERVICE_KEY", "s3cret")
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"success": False, "error": "Insufficient credits"}
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, *a, **kw):
+                return FakeResponse()
+
+        monkeypatch.setattr("app.mcp_server.httpx.AsyncClient", FakeClient)
+        ok, body = await _gateway_credit_op("/internal/credits/spend", {})
+        assert ok is False
+        assert body is not None
+        assert body["error"] == "Insufficient credits"
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_false_none(self, monkeypatch):
+        import httpx
+
+        from app.mcp_server import _gateway_credit_op
+
+        monkeypatch.setenv("GATEWAY_INTERNAL_URL", "https://gateway.example.com")
+        monkeypatch.setenv("GATEWAY_SERVICE_KEY", "s3cret")
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, *a, **kw):
+                raise httpx.ConnectError("boom")
+
+        monkeypatch.setattr("app.mcp_server.httpx.AsyncClient", FakeClient)
+        ok, body = await _gateway_credit_op("/internal/credits/spend", {})
+        assert ok is False
+        assert body is None
+
+
+@pytest.mark.fast
+class TestGatewaySpendCredits:
+    """The thin spend-credits wrapper bubbles up Gateway-provided error text."""
+
+    @pytest.mark.asyncio
+    async def test_propagates_gateway_error_message(self, monkeypatch):
+        from app.mcp_server import _gateway_spend_credits
+
+        async def fake_op(path, payload):
+            return False, {"success": False, "error": "Insufficient credits"}
+
+        monkeypatch.setattr("app.mcp_server._gateway_credit_op", fake_op)
+        ok, err = await _gateway_spend_credits("u1", 5, "desc")
+        assert ok is False
+        assert err is not None
+        assert "Insufficient credits" in err
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_gateway_is_soft_success(self, monkeypatch):
+        from app.mcp_server import _gateway_spend_credits
+
+        async def fake_op(path, payload):
+            # _gateway_credit_op returns (True, None) when the gateway env
+            # vars are missing.
+            return True, None
+
+        monkeypatch.setattr("app.mcp_server._gateway_credit_op", fake_op)
+        ok, err = await _gateway_spend_credits("u1", 5, "desc")
+        assert ok is True
+        assert err is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

E2E test `flash-mcp-roundtrip:134` ('tools/call tp_flash_generate returns expected shape and deducts credits') fails against `https://flash.timepointai.com/mcp/`:

```
expect(typeof result.id).toBe('string')  // got undefined
```

Inspecting the actual response shows the tool returns `{error: ...}` because of a Postgres foreign-key violation:

```
ForeignKeyViolationError: insert or update on table "timepoints"
violates foreign key constraint "timepoints_user_id_fkey"
DETAIL: Key (user_id)=(dbb9f8ab-…) is not present in table "users".
```

The MCP middleware authenticates the bearer via the Gateway's `/internal/auth/validate-key`, which returns a Gateway-side `user_id`. That UUID isn't guaranteed to exist in Flash's local `users` table — and `timepoints.user_id` has a FK to `users.id`. Setting it directly blows up the insert.

The MCP path also bypasses the Gateway's metering middleware, so a tp_flash_generate call never debited the Gateway credit ledger — breaking the secondary deduction assertion in the same test.

## Fix

`app/mcp_server.py`:

1. **Auto-resolve/provision a Flash User row** for the gateway user_id before creating the timepoint, mirroring `/api/v1/users/resolve` semantics (look up by `id`, then by `external_id`; create with `apple_sub='gateway:<uid>'` + `external_id=<uid>` if neither matches). The Flash User's UUID is what lands on `timepoints.user_id`.
2. **Deduct credits up-front** via the Gateway's `/internal/credits/spend` endpoint (same auth scheme as `validate-key`). If deduction fails (insufficient credits, gateway unreachable), return a structured `{error: ...}` before touching the database.
3. **Refund** on resolution/insert failure via `/internal/credits/grant`.
4. **Tag** MCP-originated timepoints with `api_source='mcp'` for observability.
5. Soft-fail gateway-credit ops when `GATEWAY_INTERNAL_URL`/`GATEWAY_SERVICE_KEY` aren't set, matching `BearerAuthMiddleware`'s local-dev behaviour.

`tests/unit/test_mcp_server.py`:

- Stub the new Gateway helpers in `_stub_generation` so existing happy-path tests keep working.
- Add 12 new tests covering: credit spend triggering on auth, insufficient-credits surfacing the gateway error, anonymous callers skipping spend, user-resolution failure refunding credits, the Flash UUID (not gateway UUID) landing on the row, `api_source='mcp'` tagging, and the underlying `_gateway_credit_op` helper across happy-path/non-200/network-error/missing-config cases.

All 60 tests in `tests/unit/test_mcp_server.py` pass locally (with pinned starlette+fastapi).

## Test plan

- [x] `pytest tests/unit/test_mcp_server.py` — 60 passed
- [ ] Once deployed: `playwright-rig` `tests/mcp_integration/flash-mcp-roundtrip.spec.ts:134` passes against `https://flash.timepointai.com/mcp/`
- [ ] Manual probe with `TP_GW_BEARER_TOKEN` confirms `tools/call tp_flash_generate { query: '...' }` returns `{id, status: 'processing', status_url, owner_id, slug, query, preset, generate_image, visibility, note}` and the gateway `/api/v1/credits/balance` drops by 5

## Related

- Task `el-61c0n` in dev-management
- The MCP path's auth resolution is at `app/middleware/bearer_auth.py` (gateway introspection); this PR adds the credit-ledger half of that integration.