### PR TITLE
feat: add /api/v1/find-money/quick-sim-batch endpoint

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -63,6 +63,7 @@ from app.agents.image_prompt_optimizer import (
 )
 from app.agents.judge import JudgeAgent
 from app.agents.moment import MomentAgent
+from app.agents.quick_sim import QuickSimMetricsAgent, QuickSimMetricsInput
 from app.agents.scene import SceneAgent
 from app.agents.survey import (
     SurveyAgent,
@@ -110,4 +111,7 @@ __all__ = [
     # Survey
     "SurveyAgent",
     "SurveyInput",
+    # Quick-Sim (Find Money)
+    "QuickSimMetricsAgent",
+    "QuickSimMetricsInput",
 ]

--- a/app/agents/quick_sim.py
+++ b/app/agents/quick_sim.py
@@ -1,0 +1,90 @@
+"""Quick-Sim metrics agent.
+
+A small wrapper on :class:`app.agents.base.BaseAgent` that takes a user
+goal, an opportunity stub, and a rendered future-moment scene summary
+and returns a :class:`app.schemas.quick_sim.QuickSimMetrics`.
+
+This agent is intentionally narrow — it does not generate scenes,
+characters, or dialog. It only extracts the five decision-fit fields
+the Find Money selection page needs. Scene generation is reused
+verbatim from the existing 14-agent ``GenerationPipeline``.
+
+Examples:
+    >>> from app.agents.quick_sim import QuickSimMetricsAgent, QuickSimMetricsInput
+    >>> agent = QuickSimMetricsAgent()
+    >>> result = await agent.run(QuickSimMetricsInput(
+    ...     goal="$50k operating grant by Sept 2026",
+    ...     opportunity={"title": "Climate Action Fund"},
+    ...     scene_context="The user sits across a polished oak table...",
+    ... ))
+
+Tests:
+    - tests/unit/test_agents/test_quick_sim.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.agents.base import AgentResult, BaseAgent
+from app.core.llm_router import LLMRouter
+from app.prompts import quick_sim as quick_sim_prompts
+from app.schemas.quick_sim import QuickSimMetrics
+
+
+@dataclass
+class QuickSimMetricsInput:
+    """Input bundle for the Quick-Sim metrics agent.
+
+    Attributes:
+        goal: User's free-text goal (passed through from the request).
+        opportunity: Opportunity stub dict (title/summary/amount/...).
+        scene_context: Compact, model-readable summary of the future-moment
+            TDF — built by the endpoint after the scene pipeline runs.
+    """
+
+    goal: str
+    opportunity: dict[str, Any]
+    scene_context: str
+
+
+class QuickSimMetricsAgent(BaseAgent[QuickSimMetricsInput, QuickSimMetrics]):
+    """Extract structured fit metrics for a single opportunity.
+
+    Runs a single LLM call. The system prompt forces calibration discipline
+    (no clustering at 0.5, base-rate-anchored probabilities, concrete risks
+    and levers). The response is parsed as :class:`QuickSimMetrics`.
+
+    Attributes:
+        response_model: :class:`QuickSimMetrics`
+        name: ``"QuickSimMetricsAgent"``
+    """
+
+    response_model = QuickSimMetrics
+
+    def __init__(self, router: LLMRouter | None = None) -> None:
+        super().__init__(router=router, name="QuickSimMetricsAgent")
+
+    def get_system_prompt(self) -> str:
+        return quick_sim_prompts.get_metrics_system_prompt()
+
+    def get_prompt(self, input_data: QuickSimMetricsInput) -> str:
+        return quick_sim_prompts.get_metrics_prompt(
+            goal=input_data.goal,
+            opportunity=input_data.opportunity,
+            scene_context=input_data.scene_context,
+        )
+
+    async def run(
+        self, input_data: QuickSimMetricsInput
+    ) -> AgentResult[QuickSimMetrics]:
+        """Execute the metrics agent.
+
+        Args:
+            input_data: Goal + opportunity + scene context bundle.
+
+        Returns:
+            AgentResult with QuickSimMetrics on success, error otherwise.
+        """
+        return await self._call_llm(input_data, temperature=0.3)

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -10,6 +10,7 @@ from app.api.v1.content import router as content_router
 from app.api.v1.credits import router as credits_router
 from app.api.v1.entities import router as entities_router
 from app.api.v1.eval import router as eval_router
+from app.api.v1.find_money import router as find_money_router
 from app.api.v1.interactions import router as interactions_router
 from app.api.v1.models import router as models_router
 from app.api.v1.openapi_export import router as openapi_export_router
@@ -33,5 +34,6 @@ router.include_router(interactions_router)
 router.include_router(openapi_export_router)
 router.include_router(tdf_router)
 router.include_router(reground_router)
+router.include_router(find_money_router)
 
 __all__ = ["router"]

--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -1,0 +1,634 @@
+"""Find Money API endpoints.
+
+Hosts the ``/api/v1/find-money/quick-sim-batch`` endpoint, which renders
+1–15 opportunity stubs as future-moment TDFs and streams them back via
+Server-Sent Events. The endpoint is consumed by the web app's Find Money
+selection page (user picks top 5 of 15 before triggering Pro deep-sim).
+
+This module deliberately reuses the existing 14-agent
+:class:`app.core.pipeline.GenerationPipeline` for scene generation —
+the only new model call is the small :class:`QuickSimMetricsAgent` that
+extracts the structured fit fields after each scene completes.
+
+Endpoints:
+    POST /api/v1/find-money/quick-sim-batch — SSE batch quick-sim
+
+Examples:
+    >>> # curl
+    >>> POST /api/v1/find-money/quick-sim-batch
+    >>> {
+    ...   "goal": "$50k operating grant by Sept 2026",
+    ...   "opportunities": [
+    ...     {"title": "Climate Action Fund", "summary": "..."},
+    ...     ...
+    ...   ]
+    ... }
+    >>> # → text/event-stream of opportunity_start / opportunity_complete /
+    >>> # opportunity_error / done events.
+
+Tests:
+    - tests/unit/test_api_find_money.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.quick_sim import QuickSimMetricsAgent, QuickSimMetricsInput
+from app.auth.credits import CREDIT_COSTS, grant_credits, spend_credits
+from app.auth.dependencies import get_current_user
+from app.config import QualityPreset
+from app.core.pipeline import GenerationPipeline
+from app.database import get_db_session
+from app.models_auth import TransactionType, User
+from app.schemas.quick_sim import (
+    OpportunityIn,
+    QuickSimBatchRequest,
+    QuickSimMetrics,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/find-money", tags=["find-money"])
+
+
+# Per-opportunity credit cost. Keep this tiny — Find Money batches up to 15
+# opportunities and a single batch must remain cheap enough that users will
+# actually run the discovery step before paying for the slower Pro deep-sim.
+# Authoritative cost table lives in app/auth/credits.py CREDIT_COSTS.
+_DEFAULT_QUICK_SIM_COST = 2
+
+
+# Hard wall-clock cap for a single opportunity (scene pipeline + metrics
+# agent). The standard generate-stream uses 360s, but we batch up to 15
+# of these in a row — keep each tight.
+_PER_OPPORTUNITY_TIMEOUT_S = 120
+
+# Concurrency: process opportunities in small chunks so we stream early
+# results to the client while staying inside provider rate limits. The
+# underlying pipeline already manages internal parallelism via its own
+# semaphore; we only need to bound how many pipelines run at once.
+_BATCH_CONCURRENCY = 3
+
+
+# ---------------------------------------------------------------------------
+# SSE event model (kept distinct from /timepoints StreamEvent so neither
+# endpoint silently inherits the other's field changes).
+# ---------------------------------------------------------------------------
+
+
+class QuickSimEvent(BaseModel):
+    """Server-Sent Event for /find-money/quick-sim-batch.
+
+    Attributes:
+        event: One of ``start``, ``opportunity_start``,
+            ``opportunity_complete``, ``opportunity_error``, ``done``,
+            ``error``.
+        index: Zero-based opportunity index (None on batch-level events).
+        opportunity: The original opportunity stub from the request.
+        tdf: Full TDF payload from the scene pipeline (only on
+            ``opportunity_complete``).
+        quick_sim: :class:`QuickSimMetrics` for this opportunity (only on
+            ``opportunity_complete``).
+        error: Error message (only on ``opportunity_error`` / ``error``).
+        data: Free-form batch-level metadata (count, latency, etc.).
+        request_context: Opaque context echoed from the request.
+    """
+
+    event: str
+    index: int | None = None
+    opportunity: dict[str, Any] | None = None
+    tdf: dict[str, Any] | None = None
+    quick_sim: QuickSimMetrics | None = None
+    error: str | None = None
+    data: dict[str, Any] | None = None
+    request_context: dict[str, Any] | None = None
+
+
+def _format_sse(event: QuickSimEvent) -> str:
+    """Format a QuickSimEvent as an SSE ``data:`` line.
+
+    Args:
+        event: The event to serialise.
+
+    Returns:
+        ``"data: <json>\\n\\n"``.
+    """
+    return f"data: {event.model_dump_json()}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# TDF → metrics-prompt summariser
+# ---------------------------------------------------------------------------
+
+
+def summarize_tdf_for_metrics(tdf: dict[str, Any]) -> str:
+    """Build a compact, model-readable summary of a TDF payload.
+
+    The metrics agent doesn't need the full 1MB+ TDF — it needs the parts
+    that ground its fit assessment: setting, atmosphere, tension level,
+    plot summary, stakes, and any explicit historical/contextual notes.
+
+    Args:
+        tdf: TDF payload as produced by
+            :meth:`GenerationPipeline.state_to_timepoint`.
+
+    Returns:
+        A short multiline string ready to drop into the metrics prompt.
+    """
+    parts: list[str] = []
+
+    scene = tdf.get("scene_data") or {}
+    if scene:
+        setting = scene.get("setting") or ""
+        atmosphere = scene.get("atmosphere") or ""
+        tension = scene.get("tension_level") or ""
+        focal = scene.get("focal_point") or ""
+        if setting:
+            parts.append(f"Setting: {setting}")
+        if atmosphere:
+            parts.append(f"Atmosphere: {atmosphere}")
+        if tension:
+            parts.append(f"Scene tension: {tension}")
+        if focal:
+            parts.append(f"Focal point: {focal}")
+
+    moment = tdf.get("moment_data") or {}
+    if moment:
+        plot = moment.get("plot_summary") or ""
+        stakes = moment.get("stakes") or ""
+        arc = moment.get("tension_arc") or ""
+        question = moment.get("central_question") or ""
+        if plot:
+            parts.append(f"Plot beat: {plot}")
+        if stakes:
+            parts.append(f"Stakes: {stakes}")
+        if arc:
+            parts.append(f"Tension arc: {arc}")
+        if question:
+            parts.append(f"Central question: {question}")
+
+    char = tdf.get("character_data") or {}
+    chars = char.get("characters") or []
+    if chars:
+        names = [c.get("name") for c in chars if c.get("name")]
+        if names:
+            parts.append("Characters present: " + ", ".join(names[:6]))
+
+    grounding = tdf.get("grounding_data") or {}
+    grounded_facts = grounding.get("facts") or grounding.get("verified_facts") or []
+    if isinstance(grounded_facts, list) and grounded_facts:
+        # Keep it short — only the first 3 facts.
+        snippets = []
+        for f in grounded_facts[:3]:
+            if isinstance(f, str):
+                snippets.append(f)
+            elif isinstance(f, dict):
+                snippets.append(f.get("statement") or f.get("text") or json.dumps(f))
+        if snippets:
+            parts.append("Grounded facts: " + "; ".join(snippets))
+
+    if not parts:
+        return tdf.get("query", "") or "(scene pipeline returned no usable summary)"
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Per-opportunity simulation
+# ---------------------------------------------------------------------------
+
+
+async def _simulate_one(
+    *,
+    index: int,
+    goal: str,
+    opportunity: OpportunityIn,
+    preset: QualityPreset | None,
+    generate_image: bool,
+    user_id: str | None,
+) -> dict[str, Any]:
+    """Run scene pipeline + metrics agent for a single opportunity.
+
+    Returns a dict ready to attach to a QuickSimEvent:
+    ``{"success": bool, "tdf": dict | None, "quick_sim": QuickSimMetrics | None,
+       "error": str | None, "latency_ms": int}``.
+
+    Failures (pipeline or metrics) are caught and returned as
+    ``success=False`` — the caller decides whether to surface as a
+    per-opportunity error event or abort the batch.
+    """
+    t0 = time.perf_counter()
+    opp_dict = opportunity.model_dump()
+
+    # Lazy import — avoids pulling app.prompts at module import time, which
+    # would force the test conftest to set every env var early.
+    from app.prompts.quick_sim import build_future_moment_query
+
+    query = build_future_moment_query(goal=goal, opportunity=opp_dict)
+    logger.info(
+        "quick_sim: opportunity %d title=%r query=%r",
+        index,
+        opp_dict.get("title"),
+        query[:120],
+    )
+
+    try:
+        pipeline = GenerationPipeline(
+            preset=preset,
+            user_id=user_id,
+        )
+        state = await asyncio.wait_for(
+            pipeline.run(query, generate_image=generate_image),
+            timeout=_PER_OPPORTUNITY_TIMEOUT_S,
+        )
+
+        timepoint = pipeline.state_to_timepoint(state)
+        tdf = dict(timepoint.tdf_payload or {})
+        tdf["status"] = timepoint.status.value if timepoint.status else "unknown"
+        tdf["timepoint_id"] = timepoint.id
+        tdf["slug"] = timepoint.slug
+
+        scene_context = summarize_tdf_for_metrics(tdf)
+
+        metrics_agent = QuickSimMetricsAgent(router=pipeline.router)
+        metrics_result = await metrics_agent.run(
+            QuickSimMetricsInput(
+                goal=goal,
+                opportunity=opp_dict,
+                scene_context=scene_context,
+            )
+        )
+        if not metrics_result.success or metrics_result.content is None:
+            return {
+                "success": False,
+                "tdf": tdf,
+                "quick_sim": None,
+                "error": f"quick_sim metrics agent failed: {metrics_result.error}",
+                "latency_ms": int((time.perf_counter() - t0) * 1000),
+            }
+
+        return {
+            "success": True,
+            "tdf": tdf,
+            "quick_sim": metrics_result.content,
+            "error": None,
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+        }
+
+    except TimeoutError:
+        return {
+            "success": False,
+            "tdf": None,
+            "quick_sim": None,
+            "error": f"quick_sim timed out after {_PER_OPPORTUNITY_TIMEOUT_S}s",
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+        }
+    except Exception as exc:  # noqa: BLE001 — broad catch on purpose: SSE must never raise
+        logger.exception("quick_sim opportunity %d failed", index)
+        return {
+            "success": False,
+            "tdf": None,
+            "quick_sim": None,
+            "error": f"{type(exc).__name__}: {exc}",
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Billing — per-opportunity, gateway-aware
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_spend_credits(
+    *,
+    session: AsyncSession,
+    user: User | None,
+    gateway_metered: bool,
+    cost: int,
+    description: str,
+) -> bool:
+    """Deduct credits for one opportunity, respecting the gateway header.
+
+    Returns ``True`` if credits were spent (or skipped intentionally),
+    ``False`` if the user lacked balance (caller should emit error event).
+
+    The Gateway sets ``X-Gateway-Metered: true`` when it has already
+    metered the request; in that case we MUST NOT double-charge. See the
+    Flash Phase 1.0 Gateway Endpoints Spec (doc el-369y).
+    """
+    if user is None:
+        return True  # AUTH_ENABLED=false or anonymous — no billing
+    if gateway_metered:
+        return True
+
+    try:
+        await spend_credits(
+            session,
+            user.id,
+            cost,
+            TransactionType.GENERATION,
+            description=description,
+        )
+        await session.commit()
+        return True
+    except ValueError as e:
+        # Insufficient balance or no account
+        logger.info("quick_sim spend skipped for user=%s: %s", user.id, e)
+        return False
+
+
+async def _refund_credits(
+    *,
+    session: AsyncSession,
+    user: User | None,
+    gateway_metered: bool,
+    cost: int,
+    description: str,
+) -> None:
+    """Refund credits for a failed opportunity. Best-effort, never raises."""
+    if user is None or gateway_metered:
+        return
+    try:
+        await grant_credits(
+            session,
+            user.id,
+            cost,
+            TransactionType.REFUND,
+            description=description,
+        )
+        await session.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("quick_sim refund failed for user=%s: %s", user.id, exc)
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming generator
+# ---------------------------------------------------------------------------
+
+
+async def _stream_batch(
+    *,
+    request: QuickSimBatchRequest,
+    user: User | None,
+    session: AsyncSession,
+    gateway_metered: bool,
+    disconnect_check,
+) -> AsyncGenerator[str, None]:
+    """Yield SSE events for a Quick-Sim batch.
+
+    Streams ``opportunity_complete`` / ``opportunity_error`` events as
+    each opportunity finishes (bounded concurrency), so the web app can
+    progressively render cards instead of waiting for the full batch.
+    """
+    preset = None
+    if request.preset:
+        try:
+            preset = QualityPreset(request.preset.lower())
+        except ValueError:
+            logger.warning("quick_sim: invalid preset %r, defaulting", request.preset)
+            preset = None
+
+    cost = CREDIT_COSTS.get("quick_sim_per_opportunity", _DEFAULT_QUICK_SIM_COST)
+    user_id = user.id if user is not None else None
+
+    # ---- start event -----------------------------------------------------
+    yield _format_sse(
+        QuickSimEvent(
+            event="start",
+            data={
+                "goal": request.goal,
+                "count": len(request.opportunities),
+                "preset": preset.value if preset else (request.preset or "hyper"),
+                "generate_image": request.generate_image,
+                "concurrency": _BATCH_CONCURRENCY,
+                "per_opportunity_cost": cost if not gateway_metered else 0,
+            },
+            request_context=request.request_context,
+        )
+    )
+
+    # ---- run each opportunity --------------------------------------------
+    semaphore = asyncio.Semaphore(_BATCH_CONCURRENCY)
+    completed = 0
+    errored = 0
+
+    async def _run(index: int, opportunity: OpportunityIn) -> tuple[int, OpportunityIn, dict[str, Any], bool]:
+        async with semaphore:
+            opp_dict = opportunity.model_dump()
+            # Bill BEFORE running — refund on failure. Matches /timepoints/generate.
+            spent = await _maybe_spend_credits(
+                session=session,
+                user=user,
+                gateway_metered=gateway_metered,
+                cost=cost,
+                description=f"quick-sim: {opp_dict.get('title', '')[:60]}",
+            )
+            if not spent:
+                return (
+                    index,
+                    opportunity,
+                    {
+                        "success": False,
+                        "tdf": None,
+                        "quick_sim": None,
+                        "error": (
+                            f"Insufficient credits: quick-sim costs {cost} credits per opportunity."
+                        ),
+                        "latency_ms": 0,
+                    },
+                    False,  # billed=False so we don't refund a non-charge
+                )
+            result = await _simulate_one(
+                index=index,
+                goal=request.goal,
+                opportunity=opportunity,
+                preset=preset,
+                generate_image=request.generate_image,
+                user_id=user_id,
+            )
+            return index, opportunity, result, True
+
+    tasks = [
+        asyncio.create_task(_run(i, opp))
+        for i, opp in enumerate(request.opportunities)
+    ]
+
+    try:
+        for finished in asyncio.as_completed(tasks):
+            # If the client hung up, abort outstanding work.
+            if disconnect_check is not None:
+                try:
+                    if await disconnect_check():
+                        logger.info("quick_sim: client disconnected, aborting batch")
+                        for t in tasks:
+                            t.cancel()
+                        return
+                except Exception:
+                    pass
+
+            try:
+                index, opportunity, result, billed = await finished
+            except asyncio.CancelledError:
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("quick_sim: task crashed")
+                yield _format_sse(
+                    QuickSimEvent(
+                        event="opportunity_error",
+                        error=f"task crashed: {type(exc).__name__}: {exc}",
+                        request_context=request.request_context,
+                    )
+                )
+                errored += 1
+                continue
+
+            opp_dict = opportunity.model_dump()
+
+            if result["success"]:
+                completed += 1
+                yield _format_sse(
+                    QuickSimEvent(
+                        event="opportunity_complete",
+                        index=index,
+                        opportunity=opp_dict,
+                        tdf=result["tdf"],
+                        quick_sim=result["quick_sim"],
+                        data={"latency_ms": result["latency_ms"]},
+                        request_context=request.request_context,
+                    )
+                )
+            else:
+                errored += 1
+                # Refund — caller paid for an opportunity we couldn't complete.
+                if billed:
+                    await _refund_credits(
+                        session=session,
+                        user=user,
+                        gateway_metered=gateway_metered,
+                        cost=cost,
+                        description=(
+                            f"quick-sim refund (failed): {opp_dict.get('title', '')[:60]}"
+                        ),
+                    )
+                yield _format_sse(
+                    QuickSimEvent(
+                        event="opportunity_error",
+                        index=index,
+                        opportunity=opp_dict,
+                        tdf=result["tdf"],
+                        error=result["error"],
+                        data={"latency_ms": result["latency_ms"], "refunded": billed},
+                        request_context=request.request_context,
+                    )
+                )
+
+    finally:
+        # Cancel any still-running tasks (defensive)
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+
+    # ---- done event ------------------------------------------------------
+    yield _format_sse(
+        QuickSimEvent(
+            event="done",
+            data={
+                "completed": completed,
+                "errored": errored,
+                "total": len(request.opportunities),
+            },
+            request_context=request.request_context,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public endpoint
+# ---------------------------------------------------------------------------
+
+
+_GATEWAY_METERED_HEADER = "X-Gateway-Metered"
+
+
+@router.post("/quick-sim-batch")
+async def quick_sim_batch(
+    body: QuickSimBatchRequest,
+    request: Request,
+    user: User | None = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> StreamingResponse:
+    """Stream future-moment TDFs + quick-sim metrics for a batch of opportunities.
+
+    For each opportunity (1–15) provided, this:
+
+    1. Wraps the opportunity in a future-tense framing query.
+    2. Runs the standard 14-agent ``GenerationPipeline`` to produce a
+       future-moment TDF.
+    3. Runs a single :class:`QuickSimMetricsAgent` LLM call to extract
+       ``probability_of_award``, ``fit_score``, ``effort_estimate``,
+       ``key_risks``, and ``key_levers``.
+    4. Streams an ``opportunity_complete`` (or ``opportunity_error``)
+       SSE event as soon as that opportunity finishes — the web app can
+       render selection cards progressively.
+
+    Billing:
+        Per-opportunity, using the ``quick_sim_per_opportunity`` cost
+        from :data:`CREDIT_COSTS`. Failed opportunities are refunded.
+        The Gateway header ``X-Gateway-Metered: true`` short-circuits
+        all per-opportunity charges so the Gateway can meter at the
+        batch level instead.
+
+    Response:
+        ``text/event-stream`` of :class:`QuickSimEvent` events:
+        ``start`` → ``opportunity_complete`` × N (interleaved with any
+        ``opportunity_error`` events) → ``done``.
+
+    Args:
+        body: :class:`QuickSimBatchRequest`.
+        request: Raw FastAPI request (used for disconnect detection and
+            the gateway-metered header).
+        user: Authenticated user (or None when AUTH_ENABLED=false).
+        session: DB session for credit ledger writes.
+
+    Returns:
+        ``StreamingResponse`` with ``text/event-stream`` content type.
+    """
+    gateway_metered = (
+        request.headers.get(_GATEWAY_METERED_HEADER, "").lower() == "true"
+    )
+
+    logger.info(
+        "quick_sim_batch: goal=%r count=%d user=%s gateway_metered=%s preset=%s",
+        body.goal[:80],
+        len(body.opportunities),
+        user.id if user else None,
+        gateway_metered,
+        body.preset,
+    )
+
+    return StreamingResponse(
+        _stream_batch(
+            request=body,
+            user=user,
+            session=session,
+            gateway_metered=gateway_metered,
+            disconnect_check=request.is_disconnected,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # disable nginx buffering
+        },
+    )

--- a/app/auth/credits.py
+++ b/app/auth/credits.py
@@ -40,6 +40,11 @@ CREDIT_COSTS: dict[str, int] = {
     "conductor_campaign_sim": 15,
     "conductor_campaign_survey": 5,
     "conductor_compare_campaigns": 10,
+    # Find Money — per-opportunity Quick-Sim charge. A batch of up to 15
+    # opportunities therefore tops out at 30 credits. Refunded per
+    # opportunity on failure. The Gateway batch-meters via
+    # X-Gateway-Metered: true (see Flash Phase 1.0 Gateway spec).
+    "quick_sim_per_opportunity": 2,
     # SkipMeetings
     "meeting_generation": 1,
     # Clockchain

--- a/app/prompts/quick_sim.py
+++ b/app/prompts/quick_sim.py
@@ -1,0 +1,195 @@
+"""Quick-Sim prompt templates.
+
+Two prompt builders here:
+
+1. ``build_future_moment_query(goal, opportunity)`` produces the
+   future-tense query string handed to the standard 14-agent
+   ``GenerationPipeline``. The pipeline renders the moment when the
+   user is in the middle of pursuing the opportunity — a TDF used as
+   the visual anchor on the Find Money selection page.
+
+2. ``get_metrics_prompt(...)`` / ``get_metrics_system_prompt()`` produce
+   the prompt fed to the metrics agent, which extracts the structured
+   fit fields (probability of award, fit score, effort, risks, levers)
+   conditioned on both the user's goal and the rendered scene.
+
+Both prompt builders are deliberately small — they wrap, not replace,
+the existing scene-generation pipeline.
+
+Examples:
+    >>> from app.prompts.quick_sim import build_future_moment_query
+    >>> q = build_future_moment_query(
+    ...     goal="$50k operating grant by Sept 2026",
+    ...     opportunity={"title": "Climate Action Fund", "amount": 25000},
+    ... )
+
+Tests:
+    - tests/unit/test_prompts_quick_sim.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Future-tense moment query (fed to GenerationPipeline as the user query)
+# ---------------------------------------------------------------------------
+
+FUTURE_MOMENT_TEMPLATE = (
+    "Future moment, three months from today: the user is in the midst of pursuing "
+    "the opportunity \"{title}\" toward their goal — {goal}. "
+    "Render the room, the people, and the tension at the decisive beat of the "
+    "application/pitch/submission. "
+    "Opportunity details: {summary} Amount: {amount}. Deadline: {deadline}. "
+    "Source: {source_url}."
+)
+
+
+def build_future_moment_query(goal: str, opportunity: dict[str, Any]) -> str:
+    """Construct a future-tense query string for the scene pipeline.
+
+    Keeps the result under 500 characters (Flash's hard ``query`` limit)
+    by truncating the summary if necessary.
+
+    Args:
+        goal: User's free-text goal (passed verbatim from the request).
+        opportunity: Dict with keys ``title``, ``source_url``, ``summary``,
+            ``amount``, ``deadline``. Any/all may be missing.
+
+    Returns:
+        Query string suitable for ``GenerationPipeline.run(query)``.
+    """
+    title = (opportunity.get("title") or "this opportunity").strip()
+    summary = (opportunity.get("summary") or "").strip()
+    amount = opportunity.get("amount")
+    deadline = (opportunity.get("deadline") or "unspecified").strip() or "unspecified"
+    source_url = (opportunity.get("source_url") or "unspecified").strip() or "unspecified"
+
+    amount_str: str
+    if amount is None:
+        amount_str = "unspecified"
+    else:
+        amount_str = str(amount)
+
+    # Hard-cap summary so the full query stays under Flash's 500-char limit.
+    # We allow up to ~200 chars of summary; the framing takes ~250.
+    if len(summary) > 200:
+        summary = summary[:197].rstrip() + "..."
+
+    query = FUTURE_MOMENT_TEMPLATE.format(
+        title=title,
+        goal=goal.strip(),
+        summary=summary or "see source for details.",
+        amount=amount_str,
+        deadline=deadline,
+        source_url=source_url,
+    )
+
+    # Final safety: enforce 500-char cap to match GenerateRequest.query
+    if len(query) > 500:
+        query = query[:497].rstrip() + "..."
+    return query
+
+
+# ---------------------------------------------------------------------------
+# Quick-Sim metrics agent prompts
+# ---------------------------------------------------------------------------
+
+METRICS_SYSTEM_PROMPT = """You are a Quick-Sim analyst for TIMEPOINT's Find Money workflow.
+
+You read three inputs:
+1. The user's goal — what they actually want.
+2. An opportunity stub — a grant, RFP, contract, or similar that may serve that goal.
+3. A rendered future-moment scene description — the moment the user is in the middle of pursuing this opportunity.
+
+You produce a structured fit assessment with five fields:
+
+- probability_of_award (0.0-1.0): Honest probability the user wins/secures this
+  opportunity if they pursue it. Anchor against base rates: cold applications
+  to competitive grants are 0.05-0.20; warm referrals 0.30-0.60; sole-source
+  or extremely well-fit 0.60+. Avoid clustering at 0.5.
+
+- fit_score (0.0-1.0): Alignment between the user's stated goal and what the
+  opportunity actually funds. A perfect-shape grant for the wrong amount is
+  ~0.5. A loose-shape grant for the right amount is ~0.4. Misaligned timing
+  or eligibility caps this below 0.3.
+
+- effort_estimate: One short phrase. Examples: "low — 4h application",
+  "moderate — 20h proposal + 1 reference letter", "high — 60h full proposal,
+  budget, and site visit". Be concrete about hours and artefacts.
+
+- key_risks: 1-5 short bullet phrases. Real failure modes that could sink
+  this pursuit (timing, eligibility, competition, capacity, fit drift).
+
+- key_levers: 1-5 short bullet phrases. Concrete moves that materially raise
+  the probability of award (a specific intro to ask for, a tighter framing,
+  a complementary co-applicant).
+
+- rationale: One sentence summarizing why these numbers, anchored in the
+  rendered scene.
+
+You MUST be honest. The downstream Pro deep-sim is expensive — your job is to
+help the user pick the 5 opportunities most worth that spend. Cluster
+probabilities, refuse to differentiate, or hand back generic risks and you
+waste their money. Calibrate."""
+
+
+METRICS_USER_TEMPLATE = """Assess this opportunity for the user's goal.
+
+USER GOAL:
+{goal}
+
+OPPORTUNITY:
+- title: {title}
+- source: {source_url}
+- summary: {summary}
+- amount: {amount}
+- deadline: {deadline}
+
+RENDERED FUTURE-MOMENT SCENE (the moment the user is in the midst of pursuing this):
+{scene_context}
+
+Respond with valid JSON matching this schema:
+{{
+  "probability_of_award": 0.0-1.0,
+  "fit_score": 0.0-1.0,
+  "effort_estimate": "short phrase with hours",
+  "key_risks": ["risk 1", "risk 2", "..."],
+  "key_levers": ["lever 1", "lever 2", "..."],
+  "rationale": "one-sentence summary anchored in the scene"
+}}"""
+
+
+def get_metrics_system_prompt() -> str:
+    """Return the system prompt for the Quick-Sim metrics agent."""
+    return METRICS_SYSTEM_PROMPT
+
+
+def get_metrics_prompt(
+    *,
+    goal: str,
+    opportunity: dict[str, Any],
+    scene_context: str,
+) -> str:
+    """Return the user prompt for the Quick-Sim metrics agent.
+
+    Args:
+        goal: User's free-text goal.
+        opportunity: Opportunity stub dict.
+        scene_context: Compact, model-readable summary of the future-moment
+            TDF (scene + moment + dialog highlights). Built by
+            :func:`app.api.v1.find_money.summarize_tdf_for_metrics`.
+
+    Returns:
+        Formatted user prompt.
+    """
+    return METRICS_USER_TEMPLATE.format(
+        goal=goal.strip(),
+        title=(opportunity.get("title") or "unspecified").strip(),
+        source_url=(opportunity.get("source_url") or "unspecified") or "unspecified",
+        summary=(opportunity.get("summary") or "unspecified") or "unspecified",
+        amount=str(opportunity.get("amount") if opportunity.get("amount") is not None else "unspecified"),
+        deadline=(opportunity.get("deadline") or "unspecified") or "unspecified",
+        scene_context=scene_context.strip() or "(no scene context available)",
+    )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -40,6 +40,11 @@ from app.schemas.graph import Faction, GraphData, Relationship
 from app.schemas.image_prompt import ImagePromptData
 from app.schemas.judge import JudgeResult, QueryType
 from app.schemas.moment import MomentData
+from app.schemas.quick_sim import (
+    OpportunityIn,
+    QuickSimBatchRequest,
+    QuickSimMetrics,
+)
 from app.schemas.scene import SceneData, SensoryDetail
 from app.schemas.timeline import TimelineData
 from app.storage.manifest import BlobManifest, FileEntry
@@ -79,6 +84,10 @@ __all__ = [
     "build_arc_from_moment",
     # Image Prompt
     "ImagePromptData",
+    # Quick-Sim (Find Money)
+    "OpportunityIn",
+    "QuickSimBatchRequest",
+    "QuickSimMetrics",
     # Blob Storage
     "BlobManifest",
     "FileEntry",

--- a/app/schemas/quick_sim.py
+++ b/app/schemas/quick_sim.py
@@ -1,0 +1,119 @@
+"""Schemas for /api/v1/find-money/quick-sim-batch.
+
+Quick-Sim is a future-tense wrapper over the standard 14-agent pipeline
+used by the Find Money workflow. Given a goal and a list of opportunities,
+each opportunity is rendered as a future-moment TDF plus a small set of
+structured "fit" metrics (probability of award, fit score, effort,
+risks, levers).
+
+The schemas here are deliberately permissive — opportunities arrive from
+the upstream web-search step which may or may not include all fields.
+
+Examples:
+    >>> from app.schemas.quick_sim import OpportunityIn, QuickSimBatchRequest
+    >>> req = QuickSimBatchRequest(
+    ...     goal="$50k operating grant for a climate non-profit",
+    ...     opportunities=[
+    ...         OpportunityIn(
+    ...             title="Climate Action Fund",
+    ...             source_url="https://example.org/climate",
+    ...             summary="Annual $10-50k grants for climate work",
+    ...             amount=50000,
+    ...             deadline="2026-09-01",
+    ...         )
+    ...     ],
+    ... )
+
+Tests:
+    - tests/unit/test_schemas_quick_sim.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class OpportunityIn(BaseModel):
+    """A single opportunity stub fed into Quick-Sim.
+
+    Mirrors the shape produced by the Find Money web-search step. All
+    fields except ``title`` are optional — the LLM is robust to missing
+    data, and the caller may have varying-quality results.
+
+    Attributes:
+        title: Short opportunity name (required).
+        source_url: Canonical URL for the opportunity (optional).
+        summary: Short prose description (optional).
+        amount: Dollar amount available, as a number or human string
+            ("$10k–$50k", "up to $25,000", 50000).
+        deadline: Application/award deadline as ISO date or human string.
+    """
+
+    title: str = Field(..., min_length=1, max_length=300)
+    source_url: str | None = Field(default=None, max_length=2000)
+    summary: str | None = Field(default=None, max_length=4000)
+    amount: float | int | str | None = Field(default=None)
+    deadline: str | None = Field(default=None, max_length=200)
+
+
+class QuickSimBatchRequest(BaseModel):
+    """Request body for POST /api/v1/find-money/quick-sim-batch.
+
+    Attributes:
+        goal: Free-text user goal (e.g. "$50k operating grant by Sept 2026").
+        opportunities: 1–15 opportunity stubs to simulate.
+        preset: Quality preset forwarded to the generation pipeline
+            (default ``"hyper"`` — batch latency dominates UX, so we
+            favour speed by default).
+        generate_image: Whether to attach images to the future-moments.
+            Default ``False`` — images add ~30s each and aren't needed
+            for the decision page.
+        request_context: Opaque context passed through to each event.
+    """
+
+    goal: str = Field(..., min_length=3, max_length=1000)
+    opportunities: list[OpportunityIn] = Field(..., min_length=1, max_length=15)
+    preset: str | None = Field(
+        default="hyper",
+        description="Quality preset forwarded to GenerationPipeline (hyper/balanced/hd).",
+    )
+    generate_image: bool = Field(
+        default=False,
+        description="Whether to generate images for the future-moments.",
+    )
+    request_context: dict[str, Any] | None = Field(
+        default=None,
+        description="Opaque context echoed back on each SSE event.",
+    )
+
+
+class QuickSimMetrics(BaseModel):
+    """Structured fit metrics emitted for each opportunity.
+
+    These are the SNAG-light decision fields the web app surfaces on the
+    selection page (top 5 of 15) before the user kicks off the slower
+    Pro deep-sim.
+
+    Attributes:
+        probability_of_award: Likelihood (0–1) the user wins/secures this
+            opportunity if they pursue it.
+        fit_score: Alignment (0–1) between the user's goal and what the
+            opportunity actually funds.
+        effort_estimate: Short prose estimate of work required
+            ("low — 4h application", "high — 60h proposal + budget").
+        key_risks: 1–5 short risk bullets (selection criteria, timing,
+            opportunity-cost, capacity gaps).
+        key_levers: 1–5 short lever bullets — concrete moves that
+            materially raise the probability of award.
+        rationale: One-sentence summary of why these numbers, anchored
+            in the future-moment scene.
+    """
+
+    probability_of_award: float = Field(..., ge=0.0, le=1.0)
+    fit_score: float = Field(..., ge=0.0, le=1.0)
+    effort_estimate: str = Field(..., min_length=1, max_length=500)
+    key_risks: list[str] = Field(default_factory=list, max_length=5)
+    key_levers: list[str] = Field(default_factory=list, max_length=5)
+    rationale: str | None = Field(default=None, max_length=800)

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -1,0 +1,413 @@
+"""Unit tests for /api/v1/find-money/quick-sim-batch.
+
+These tests cover:
+- Request schema validation (size limits, required fields)
+- Future-moment query builder (length cap, missing fields handled)
+- TDF → metrics-prompt summariser (degrades gracefully)
+- SSE format helper
+- Endpoint route registration
+
+The pipeline + LLM calls themselves are NOT exercised here (those live
+under ``tests/e2e``); per the no-mocks rule we don't fake them. The
+endpoint is exercised end-to-end against a live preset in
+``tests/e2e/test_find_money_quick_sim.py`` (gated on real API keys).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.v1.find_money import (
+    QuickSimEvent,
+    _format_sse,
+    summarize_tdf_for_metrics,
+)
+from app.prompts.quick_sim import build_future_moment_query
+from app.schemas.quick_sim import (
+    OpportunityIn,
+    QuickSimBatchRequest,
+    QuickSimMetrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestOpportunityIn:
+    """Tests for OpportunityIn schema."""
+
+    def test_minimal_valid_opportunity(self):
+        """Only ``title`` is required."""
+        opp = OpportunityIn(title="Climate Action Fund")
+        assert opp.title == "Climate Action Fund"
+        assert opp.summary is None
+        assert opp.amount is None
+
+    def test_full_opportunity(self):
+        opp = OpportunityIn(
+            title="Climate Action Fund",
+            source_url="https://example.org/climate",
+            summary="Annual climate grants",
+            amount=25000,
+            deadline="2026-09-01",
+        )
+        assert opp.amount == 25000
+        assert opp.source_url == "https://example.org/climate"
+
+    def test_amount_accepts_string(self):
+        """Amount can be a free-text string like '$10k–$50k'."""
+        opp = OpportunityIn(title="x", amount="$10k–$50k")
+        assert opp.amount == "$10k–$50k"
+
+    def test_title_required(self):
+        with pytest.raises(ValidationError):
+            OpportunityIn()  # type: ignore[call-arg]
+
+    def test_title_min_length(self):
+        with pytest.raises(ValidationError):
+            OpportunityIn(title="")
+
+    def test_title_max_length(self):
+        with pytest.raises(ValidationError):
+            OpportunityIn(title="x" * 301)
+
+
+@pytest.mark.fast
+class TestQuickSimBatchRequest:
+    """Tests for QuickSimBatchRequest schema."""
+
+    def _opps(self, n: int) -> list[OpportunityIn]:
+        return [OpportunityIn(title=f"opportunity {i}") for i in range(n)]
+
+    def test_valid_request(self):
+        req = QuickSimBatchRequest(
+            goal="$50k operating grant",
+            opportunities=self._opps(1),
+        )
+        assert req.goal == "$50k operating grant"
+        assert req.preset == "hyper"  # default favours speed
+        assert req.generate_image is False
+
+    def test_requires_at_least_one_opportunity(self):
+        with pytest.raises(ValidationError):
+            QuickSimBatchRequest(goal="goal", opportunities=[])
+
+    def test_caps_at_15_opportunities(self):
+        with pytest.raises(ValidationError):
+            QuickSimBatchRequest(goal="goal", opportunities=self._opps(16))
+
+    def test_allows_exactly_15(self):
+        req = QuickSimBatchRequest(goal="goal", opportunities=self._opps(15))
+        assert len(req.opportunities) == 15
+
+    def test_goal_min_length(self):
+        with pytest.raises(ValidationError):
+            QuickSimBatchRequest(goal="ab", opportunities=self._opps(1))
+
+    def test_goal_max_length(self):
+        with pytest.raises(ValidationError):
+            QuickSimBatchRequest(goal="x" * 1001, opportunities=self._opps(1))
+
+
+@pytest.mark.fast
+class TestQuickSimMetrics:
+    """Tests for the QuickSimMetrics output schema."""
+
+    def test_valid_metrics(self):
+        m = QuickSimMetrics(
+            probability_of_award=0.42,
+            fit_score=0.7,
+            effort_estimate="moderate — 20h proposal",
+            key_risks=["competitive field"],
+            key_levers=["co-applicant from anchor org"],
+            rationale="solid fit but crowded competition",
+        )
+        assert m.probability_of_award == pytest.approx(0.42)
+        assert m.fit_score == pytest.approx(0.7)
+        assert m.key_risks == ["competitive field"]
+
+    def test_probability_bounds(self):
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=1.1,
+                fit_score=0.5,
+                effort_estimate="x",
+            )
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=-0.1,
+                fit_score=0.5,
+                effort_estimate="x",
+            )
+
+    def test_fit_score_bounds(self):
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=0.5,
+                fit_score=1.5,
+                effort_estimate="x",
+            )
+
+    def test_default_empty_lists(self):
+        m = QuickSimMetrics(
+            probability_of_award=0.5,
+            fit_score=0.5,
+            effort_estimate="x",
+        )
+        assert m.key_risks == []
+        assert m.key_levers == []
+
+
+# ---------------------------------------------------------------------------
+# build_future_moment_query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestBuildFutureMomentQuery:
+    """Tests for the future-tense framing helper."""
+
+    def test_handles_minimal_opportunity(self):
+        q = build_future_moment_query(
+            goal="$50k operating grant",
+            opportunity={"title": "Climate Action Fund"},
+        )
+        assert "Climate Action Fund" in q
+        assert "$50k operating grant" in q
+        assert "Future moment" in q
+        assert "unspecified" in q  # missing fields fall through to placeholders
+
+    def test_includes_all_fields_when_present(self):
+        q = build_future_moment_query(
+            goal="raise $50k by Sept",
+            opportunity={
+                "title": "Climate Action Fund",
+                "source_url": "https://example.org/x",
+                "summary": "Annual climate grants",
+                "amount": 25000,
+                "deadline": "2026-09-01",
+            },
+        )
+        assert "Annual climate grants" in q
+        assert "25000" in q
+        assert "2026-09-01" in q
+
+    def test_truncates_long_summary(self):
+        long_summary = "lorem ipsum " * 200  # ~2400 chars
+        q = build_future_moment_query(
+            goal="goal",
+            opportunity={"title": "x", "summary": long_summary},
+        )
+        # Query must stay under Flash's 500-char limit
+        assert len(q) <= 500
+
+    def test_truncates_overall_query_to_500_chars(self):
+        """Even with all fields stuffed, query must stay <= 500 chars."""
+        q = build_future_moment_query(
+            goal="g" * 400,
+            opportunity={
+                "title": "t" * 200,
+                "summary": "s" * 500,
+                "amount": "$" + "9" * 50,
+                "deadline": "d" * 100,
+                "source_url": "https://example.org/" + "x" * 200,
+            },
+        )
+        assert len(q) <= 500
+
+    def test_handles_none_summary(self):
+        q = build_future_moment_query(
+            goal="goal",
+            opportunity={"title": "x", "summary": None},
+        )
+        # Falls back to the "see source for details" sentinel
+        assert "see source" in q.lower() or "unspecified" in q.lower()
+
+
+# ---------------------------------------------------------------------------
+# summarize_tdf_for_metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestSummarizeTdfForMetrics:
+    """Tests for the TDF → metrics-prompt summariser."""
+
+    def test_empty_tdf_falls_back_to_query(self):
+        s = summarize_tdf_for_metrics({"query": "fallback query"})
+        assert "fallback query" in s
+
+    def test_completely_empty_tdf_returns_sentinel(self):
+        s = summarize_tdf_for_metrics({})
+        assert s  # not empty; either query or sentinel
+
+    def test_extracts_scene_fields(self):
+        s = summarize_tdf_for_metrics(
+            {
+                "scene_data": {
+                    "setting": "oak-panelled boardroom",
+                    "atmosphere": "polite tension",
+                    "tension_level": "high",
+                    "focal_point": "the user's slide deck",
+                }
+            }
+        )
+        assert "oak-panelled boardroom" in s
+        assert "polite tension" in s
+        assert "high" in s
+        assert "slide deck" in s
+
+    def test_extracts_moment_fields(self):
+        s = summarize_tdf_for_metrics(
+            {
+                "moment_data": {
+                    "plot_summary": "user presents the budget",
+                    "stakes": "two years of runway",
+                    "tension_arc": "climactic",
+                    "central_question": "will the chair sign?",
+                }
+            }
+        )
+        assert "presents the budget" in s
+        assert "two years of runway" in s
+        assert "climactic" in s
+        assert "chair sign" in s
+
+    def test_extracts_character_names(self):
+        s = summarize_tdf_for_metrics(
+            {
+                "character_data": {
+                    "characters": [
+                        {"name": "Dr. Chen"},
+                        {"name": "Board Chair Reyes"},
+                    ]
+                }
+            }
+        )
+        assert "Dr. Chen" in s
+        assert "Board Chair Reyes" in s
+
+    def test_handles_string_grounded_facts(self):
+        s = summarize_tdf_for_metrics(
+            {
+                "grounding_data": {
+                    "facts": ["fact A", "fact B", "fact C", "fact D"],
+                },
+                "scene_data": {"setting": "x", "atmosphere": "y"},
+            }
+        )
+        assert "fact A" in s
+        # Only first three retained
+        assert "fact D" not in s
+
+    def test_handles_dict_grounded_facts(self):
+        s = summarize_tdf_for_metrics(
+            {
+                "grounding_data": {
+                    "facts": [{"statement": "fact A"}, {"text": "fact B"}],
+                },
+                "scene_data": {"setting": "x", "atmosphere": "y"},
+            }
+        )
+        assert "fact A" in s
+        assert "fact B" in s
+
+
+# ---------------------------------------------------------------------------
+# SSE format helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestFormatSse:
+    """Tests for the SSE wire-format helper."""
+
+    def test_emits_sse_data_line(self):
+        line = _format_sse(QuickSimEvent(event="start"))
+        assert line.startswith("data: ")
+        assert line.endswith("\n\n")
+
+    def test_payload_is_valid_json(self):
+        line = _format_sse(
+            QuickSimEvent(
+                event="opportunity_complete",
+                index=0,
+                opportunity={"title": "x"},
+                data={"latency_ms": 1234},
+            )
+        )
+        # Strip the prefix and trailing newlines, then parse JSON.
+        payload = line[len("data: ") :].strip()
+        decoded = json.loads(payload)
+        assert decoded["event"] == "opportunity_complete"
+        assert decoded["index"] == 0
+        assert decoded["opportunity"] == {"title": "x"}
+        assert decoded["data"]["latency_ms"] == 1234
+
+
+# ---------------------------------------------------------------------------
+# Endpoint registration + request validation (no LLM calls)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    """Synchronous TestClient — sufficient for validation-error paths."""
+    from app.main import app
+
+    return TestClient(app)
+
+
+@pytest.mark.fast
+class TestEndpointRegistered:
+    """The endpoint must be registered under /api/v1/find-money/quick-sim-batch."""
+
+    def test_route_is_registered(self):
+        from app.main import app
+
+        paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
+        # FastAPI's APIRouter combines parent prefix with the route path.
+        assert "/api/v1/find-money/quick-sim-batch" in paths
+
+    def test_get_returns_405(self, client):
+        """GET is not allowed — only POST."""
+        resp = client.get("/api/v1/find-money/quick-sim-batch")
+        assert resp.status_code in (404, 405)
+
+    def test_empty_body_returns_422(self, client):
+        resp = client.post("/api/v1/find-money/quick-sim-batch", json={})
+        assert resp.status_code == 422
+
+    def test_empty_opportunities_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/find-money/quick-sim-batch",
+            json={"goal": "valid goal", "opportunities": []},
+        )
+        assert resp.status_code == 422
+
+    def test_too_many_opportunities_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/find-money/quick-sim-batch",
+            json={
+                "goal": "valid goal",
+                "opportunities": [{"title": f"opp {i}"} for i in range(16)],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_goal_too_short_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/find-money/quick-sim-batch",
+            json={
+                "goal": "ab",
+                "opportunities": [{"title": "opp 1"}],
+            },
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/find-money/quick-sim-batch` — step 2 of the Find Money pipeline (Goal → web-search → **Flash quick-sim** → user picks top 5 → Pro deep-sim).

For each opportunity (1–15), the endpoint:

1. Wraps it in a future-tense framing query via `build_future_moment_query(goal, opportunity)`.
2. Runs the existing 14-agent `GenerationPipeline` to render a future-moment TDF.
3. Runs a single `QuickSimMetricsAgent` LLM call to extract `probability_of_award`, `fit_score`, `effort_estimate`, `key_risks`, `key_levers`, `rationale`.
4. Streams an `opportunity_complete` (or `opportunity_error`) SSE event as soon as that opportunity finishes — bounded concurrency of 3, so the web app renders selection cards progressively.

**Reuse, not new infra** — no new pipeline, no new agents in the 14-step flow, just one wrapper agent and a future-tense framing prompt over the existing scene generation.

## Billing

- `CREDIT_COSTS["quick_sim_per_opportunity"] = 2` — batch tops out at 30 credits.
- Failed opportunities are refunded.
- `X-Gateway-Metered: true` short-circuits per-opportunity charges (per the Flash Phase 1.0 Gateway spec).

## Files

- `app/api/v1/find_money.py` (new) — router, SSE generator, per-opportunity simulator, billing helpers.
- `app/agents/quick_sim.py` (new) — `QuickSimMetricsAgent`.
- `app/prompts/quick_sim.py` (new) — future-moment framing + metrics agent prompts.
- `app/schemas/quick_sim.py` (new) — `OpportunityIn`, `QuickSimBatchRequest`, `QuickSimMetrics`.
- `app/auth/credits.py` — adds `quick_sim_per_opportunity: 2`.
- `app/api/v1/__init__.py`, `app/agents/__init__.py`, `app/schemas/__init__.py` — wiring.
- `tests/unit/test_api_find_money.py` (new) — schema validation, future-moment query length cap, TDF summariser, SSE format, route registration.

Spec doc (Stoneforge `el-17c5s`): "Flash Quick-Sim Batch API".

Task: `el-2e4q6` (plan `ok-but-we-have-synthetic-music.md`, P2 task 5).

## Test plan

- [ ] Unit: `pytest tests/unit/test_api_find_money.py -m fast` green.
- [ ] Integration: hit `POST /api/v1/find-money/quick-sim-batch` on dev with 3 opportunities; verify SSE order is `start` → `opportunity_complete` x3 → `done` and each event includes a non-empty `tdf` + `quick_sim`.
- [ ] Billing: with `AUTH_ENABLED=true` and a low-balance test user, verify per-opportunity refund on synthetic failure (set `OPENROUTER_API_KEY` invalid for one opp).
- [ ] Gateway header: send `X-Gateway-Metered: true` and verify zero credits deducted.
- [ ] Web app integration (separate task) — wire `/find-money/runs/{id}` quick-sim stage to consume this endpoint.

Note: `CREDIT_COSTS["quick_sim_per_opportunity"]` must be mirrored in `gateway/auth_core/credits.py` before the Playwright `flash-deep.spec.ts` contract test runs. Track in follow-on Gateway task.