### PR TITLE
fix(find-money): quick-sim-batch returns JSON + real GenerationPipeline integration test (el-155tv)

### DIFF
--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -470,8 +470,7 @@ async def _run_batch(
                         "tdf": None,
                         "quick_sim": None,
                         "error": (
-                            f"Insufficient credits: quick-sim costs {cost} "
-                            "credits per opportunity."
+                            f"Insufficient credits: quick-sim costs {cost} credits per opportunity."
                         ),
                         "latency_ms": 0,
                     },

--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -1,9 +1,12 @@
 """Find Money API endpoints.
 
 Hosts the ``/api/v1/find-money/quick-sim-batch`` endpoint, which renders
-1–15 opportunity stubs as future-moment TDFs and streams them back via
-Server-Sent Events. The endpoint is consumed by the web app's Find Money
-selection page (user picks top 5 of 15 before triggering Pro deep-sim).
+1–15 opportunity stubs as future-moment TDFs and returns them as a
+single JSON object. The endpoint is consumed by the web app's Find
+Money pipeline (``run_quick_sim`` in
+``timepoint-web-app/app/find_money/runs/jobs.py``) — a server-side
+background job, not a browser, so there is no value in streaming, and
+the API gateway cannot proxy ``text/event-stream`` responses.
 
 This module deliberately reuses the existing 14-agent
 :class:`app.core.pipeline.GenerationPipeline` for scene generation —
@@ -11,7 +14,7 @@ the only new model call is the small :class:`QuickSimMetricsAgent` that
 extracts the structured fit fields after each scene completes.
 
 Endpoints:
-    POST /api/v1/find-money/quick-sim-batch — SSE batch quick-sim
+    POST /api/v1/find-money/quick-sim-batch — batch quick-sim (JSON)
 
 Examples:
     >>> # curl
@@ -23,8 +26,8 @@ Examples:
     ...     ...
     ...   ]
     ... }
-    >>> # → text/event-stream of opportunity_start / opportunity_complete /
-    >>> # opportunity_error / done events.
+    >>> # → 200 {"tdfs": [ ...one entry per opportunity... ],
+    >>> #         "completed": N, "errored": M, "total": T}
 
 Tests:
     - tests/unit/test_api_find_money.py
@@ -36,12 +39,9 @@ import asyncio
 import json
 import logging
 import time
-from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.quick_sim import QuickSimMetricsAgent, QuickSimMetricsInput
@@ -54,7 +54,8 @@ from app.models_auth import TransactionType, User
 from app.schemas.quick_sim import (
     OpportunityIn,
     QuickSimBatchRequest,
-    QuickSimMetrics,
+    QuickSimBatchResponse,
+    QuickSimTdfEntry,
 )
 
 logger = logging.getLogger(__name__)
@@ -74,57 +75,52 @@ _DEFAULT_QUICK_SIM_COST = 2
 # of these in a row — keep each tight.
 _PER_OPPORTUNITY_TIMEOUT_S = 120
 
-# Concurrency: process opportunities in small chunks so we stream early
-# results to the client while staying inside provider rate limits. The
-# underlying pipeline already manages internal parallelism via its own
-# semaphore; we only need to bound how many pipelines run at once.
+# Concurrency: process opportunities in small chunks so we stay inside
+# provider rate limits. The underlying pipeline already manages internal
+# parallelism via its own semaphore; we only need to bound how many
+# pipelines run at once.
 _BATCH_CONCURRENCY = 3
 
 
 # ---------------------------------------------------------------------------
-# SSE event model (kept distinct from /timepoints StreamEvent so neither
-# endpoint silently inherits the other's field changes).
+# GenerationPipeline construction seam
 # ---------------------------------------------------------------------------
 
 
-class QuickSimEvent(BaseModel):
-    """Server-Sent Event for /find-money/quick-sim-batch.
+def _build_generation_pipeline(
+    *,
+    preset: QualityPreset | None,
+    user_id: str | None,
+    entity_ids: list[str] | None = None,
+) -> GenerationPipeline:
+    """Construct the 14-agent pipeline with the kwargs Quick-Sim relies on.
 
-    Attributes:
-        event: One of ``start``, ``opportunity_start``,
-            ``opportunity_complete``, ``opportunity_error``, ``done``,
-            ``error``.
-        index: Zero-based opportunity index (None on batch-level events).
-        opportunity: The original opportunity stub from the request.
-        tdf: Full TDF payload from the scene pipeline (only on
-            ``opportunity_complete``).
-        quick_sim: :class:`QuickSimMetrics` for this opportunity (only on
-            ``opportunity_complete``).
-        error: Error message (only on ``opportunity_error`` / ``error``).
-        data: Free-form batch-level metadata (count, latency, etc.).
-        request_context: Opaque context echoed from the request.
-    """
+    This is a deliberate, narrow seam: the handler builds every pipeline
+    through this one function, so a single real integration test
+    (``tests/unit/test_api_find_money.py::TestGenerationPipelineIntegration``)
+    can construct a real :class:`GenerationPipeline` here and fail CI on
+    an ``__init__`` signature drift.
 
-    event: str
-    index: int | None = None
-    opportunity: dict[str, Any] | None = None
-    tdf: dict[str, Any] | None = None
-    quick_sim: QuickSimMetrics | None = None
-    error: str | None = None
-    data: dict[str, Any] | None = None
-    request_context: dict[str, Any] | None = None
-
-
-def _format_sse(event: QuickSimEvent) -> str:
-    """Format a QuickSimEvent as an SSE ``data:`` line.
+    PR #45 shipped a runtime crash —
+    ``TypeError: GenerationPipeline.__init__() got an unexpected keyword
+    argument 'user_id'`` — precisely because its unit tests never built a
+    real pipeline. Routing construction through this helper makes that
+    class of regression catchable without a live LLM call.
 
     Args:
-        event: The event to serialise.
+        preset: Quality preset forwarded to the pipeline (or ``None``).
+        user_id: Authenticated user id, forwarded for entity-visibility
+            filtering (``None`` when ``AUTH_ENABLED=false`` / anonymous).
+        entity_ids: Optional Clockchain figure ids to pre-populate.
 
     Returns:
-        ``"data: <json>\\n\\n"``.
+        A ready-to-run :class:`GenerationPipeline`.
     """
-    return f"data: {event.model_dump_json()}\n\n"
+    return GenerationPipeline(
+        preset=preset,
+        user_id=user_id,
+        entity_ids=entity_ids,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -220,13 +216,13 @@ async def _simulate_one(
 ) -> dict[str, Any]:
     """Run scene pipeline + metrics agent for a single opportunity.
 
-    Returns a dict ready to attach to a QuickSimEvent:
+    Returns a dict ready to fold into a :class:`QuickSimTdfEntry`:
     ``{"success": bool, "tdf": dict | None, "quick_sim": QuickSimMetrics | None,
        "error": str | None, "latency_ms": int}``.
 
     Failures (pipeline or metrics) are caught and returned as
-    ``success=False`` — the caller decides whether to surface as a
-    per-opportunity error event or abort the batch.
+    ``success=False`` — the caller decides whether to refund credits and
+    how to surface the failure in the batch response.
     """
     t0 = time.perf_counter()
     opp_dict = opportunity.model_dump()
@@ -244,10 +240,7 @@ async def _simulate_one(
     )
 
     try:
-        pipeline = GenerationPipeline(
-            preset=preset,
-            user_id=user_id,
-        )
+        pipeline = _build_generation_pipeline(preset=preset, user_id=user_id)
         state = await asyncio.wait_for(
             pipeline.run(query, generate_image=generate_image),
             timeout=_PER_OPPORTUNITY_TIMEOUT_S,
@@ -294,7 +287,7 @@ async def _simulate_one(
             "error": f"quick_sim timed out after {_PER_OPPORTUNITY_TIMEOUT_S}s",
             "latency_ms": int((time.perf_counter() - t0) * 1000),
         }
-    except Exception as exc:  # noqa: BLE001 — broad catch on purpose: SSE must never raise
+    except Exception as exc:  # noqa: BLE001 — broad catch: one bad opportunity must not sink the batch
         logger.exception("quick_sim opportunity %d failed", index)
         return {
             "success": False,
@@ -303,6 +296,55 @@ async def _simulate_one(
             "error": f"{type(exc).__name__}: {exc}",
             "latency_ms": int((time.perf_counter() - t0) * 1000),
         }
+
+
+# ---------------------------------------------------------------------------
+# Result → response-entry builder
+# ---------------------------------------------------------------------------
+
+
+def _build_tdf_entry(
+    *,
+    index: int,
+    opportunity: OpportunityIn,
+    result: dict[str, Any],
+) -> QuickSimTdfEntry:
+    """Fold a :func:`_simulate_one` result into a :class:`QuickSimTdfEntry`.
+
+    Pure function (no I/O) — the flat ``tdf_ref`` / ``opportunity_index`` /
+    ``title`` / ``url`` / ``summary`` / ``probability`` / ``fit_score`` /
+    ``effort_score`` / ``amount_usd`` / ``source`` shape is what the
+    web-app's Find Money pipeline pairs against
+    (``_seed_quick_sim_tdfs``), so real Flash output and the web-app
+    seed fallback are interchangeable to the selection page.
+
+    Args:
+        index: Zero-based opportunity index (request order).
+        opportunity: The original opportunity stub.
+        result: A :func:`_simulate_one` result dict.
+
+    Returns:
+        A :class:`QuickSimTdfEntry` — one entry for this opportunity.
+    """
+    success = bool(result.get("success"))
+    metrics = result.get("quick_sim")  # QuickSimMetrics | None
+
+    return QuickSimTdfEntry(
+        tdf_ref=f"flash:quick:{index}",
+        opportunity_index=index,
+        title=opportunity.title,
+        url=opportunity.source_url,
+        summary=opportunity.summary,
+        probability=metrics.probability_of_award if metrics is not None else None,
+        fit_score=metrics.fit_score if metrics is not None else None,
+        effort_score=metrics.effort_score if metrics is not None else None,
+        amount_usd=opportunity.amount,
+        source="flash-quick-sim" if success else "flash-quick-sim-error",
+        tdf=result.get("tdf"),
+        quick_sim=metrics,
+        error=result.get("error"),
+        latency_ms=int(result.get("latency_ms", 0) or 0),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +363,8 @@ async def _maybe_spend_credits(
     """Deduct credits for one opportunity, respecting the gateway header.
 
     Returns ``True`` if credits were spent (or skipped intentionally),
-    ``False`` if the user lacked balance (caller should emit error event).
+    ``False`` if the user lacked balance (caller should mark the
+    opportunity as an error and not simulate it).
 
     The Gateway sets ``X-Gateway-Metered: true`` when it has already
     metered the request; in that case we MUST NOT double-charge. See the
@@ -373,25 +416,26 @@ async def _refund_credits(
 
 
 # ---------------------------------------------------------------------------
-# SSE streaming generator
+# Batch runner
 # ---------------------------------------------------------------------------
 
 
-async def _stream_batch(
+async def _run_batch(
     *,
     request: QuickSimBatchRequest,
     user: User | None,
     session: AsyncSession,
     gateway_metered: bool,
-    disconnect_check,
-) -> AsyncGenerator[str, None]:
-    """Yield SSE events for a Quick-Sim batch.
+) -> QuickSimBatchResponse:
+    """Run a Quick-Sim batch and return the full JSON response.
 
-    Streams ``opportunity_complete`` / ``opportunity_error`` events as
-    each opportunity finishes (bounded concurrency), so the web app can
-    progressively render cards instead of waiting for the full batch.
+    Each opportunity is billed before it runs (per-opportunity, unless
+    the Gateway already metered the batch) and refunded if it fails.
+    Up to :data:`_BATCH_CONCURRENCY` opportunities run at once; the
+    response lists one :class:`QuickSimTdfEntry` per opportunity,
+    ordered by request index, so it always pairs 1:1 with the request.
     """
-    preset = None
+    preset: QualityPreset | None = None
     if request.preset:
         try:
             preset = QualityPreset(request.preset.lower())
@@ -402,26 +446,7 @@ async def _stream_batch(
     cost = CREDIT_COSTS.get("quick_sim_per_opportunity", _DEFAULT_QUICK_SIM_COST)
     user_id = user.id if user is not None else None
 
-    # ---- start event -----------------------------------------------------
-    yield _format_sse(
-        QuickSimEvent(
-            event="start",
-            data={
-                "goal": request.goal,
-                "count": len(request.opportunities),
-                "preset": preset.value if preset else (request.preset or "hyper"),
-                "generate_image": request.generate_image,
-                "concurrency": _BATCH_CONCURRENCY,
-                "per_opportunity_cost": cost if not gateway_metered else 0,
-            },
-            request_context=request.request_context,
-        )
-    )
-
-    # ---- run each opportunity --------------------------------------------
     semaphore = asyncio.Semaphore(_BATCH_CONCURRENCY)
-    completed = 0
-    errored = 0
 
     async def _run(
         index: int, opportunity: OpportunityIn
@@ -445,7 +470,8 @@ async def _stream_batch(
                         "tdf": None,
                         "quick_sim": None,
                         "error": (
-                            f"Insufficient credits: quick-sim costs {cost} credits per opportunity."
+                            f"Insufficient credits: quick-sim costs {cost} "
+                            "credits per opportunity."
                         ),
                         "latency_ms": 0,
                     },
@@ -462,93 +488,37 @@ async def _stream_batch(
             return index, opportunity, result, True
 
     tasks = [asyncio.create_task(_run(i, opp)) for i, opp in enumerate(request.opportunities)]
+    settled = await asyncio.gather(*tasks)
 
-    try:
-        for finished in asyncio.as_completed(tasks):
-            # If the client hung up, abort outstanding work.
-            if disconnect_check is not None:
-                try:
-                    if await disconnect_check():
-                        logger.info("quick_sim: client disconnected, aborting batch")
-                        for t in tasks:
-                            t.cancel()
-                        return
-                except Exception:
-                    pass
+    entries: list[QuickSimTdfEntry] = []
+    completed = 0
+    errored = 0
 
-            try:
-                index, opportunity, result, billed = await finished
-            except asyncio.CancelledError:
-                continue
-            except Exception as exc:  # noqa: BLE001
-                logger.exception("quick_sim: task crashed")
-                yield _format_sse(
-                    QuickSimEvent(
-                        event="opportunity_error",
-                        error=f"task crashed: {type(exc).__name__}: {exc}",
-                        request_context=request.request_context,
-                    )
+    for index, opportunity, result, billed in settled:
+        if result.get("success"):
+            completed += 1
+        else:
+            errored += 1
+            # Refund — caller paid for an opportunity we couldn't complete.
+            if billed:
+                opp_title = (opportunity.title or "")[:60]
+                await _refund_credits(
+                    session=session,
+                    user=user,
+                    gateway_metered=gateway_metered,
+                    cost=cost,
+                    description=f"quick-sim refund (failed): {opp_title}",
                 )
-                errored += 1
-                continue
+        entries.append(_build_tdf_entry(index=index, opportunity=opportunity, result=result))
 
-            opp_dict = opportunity.model_dump()
+    entries.sort(key=lambda e: e.opportunity_index)
 
-            if result["success"]:
-                completed += 1
-                yield _format_sse(
-                    QuickSimEvent(
-                        event="opportunity_complete",
-                        index=index,
-                        opportunity=opp_dict,
-                        tdf=result["tdf"],
-                        quick_sim=result["quick_sim"],
-                        data={"latency_ms": result["latency_ms"]},
-                        request_context=request.request_context,
-                    )
-                )
-            else:
-                errored += 1
-                # Refund — caller paid for an opportunity we couldn't complete.
-                if billed:
-                    await _refund_credits(
-                        session=session,
-                        user=user,
-                        gateway_metered=gateway_metered,
-                        cost=cost,
-                        description=(
-                            f"quick-sim refund (failed): {opp_dict.get('title', '')[:60]}"
-                        ),
-                    )
-                yield _format_sse(
-                    QuickSimEvent(
-                        event="opportunity_error",
-                        index=index,
-                        opportunity=opp_dict,
-                        tdf=result["tdf"],
-                        error=result["error"],
-                        data={"latency_ms": result["latency_ms"], "refunded": billed},
-                        request_context=request.request_context,
-                    )
-                )
-
-    finally:
-        # Cancel any still-running tasks (defensive)
-        for t in tasks:
-            if not t.done():
-                t.cancel()
-
-    # ---- done event ------------------------------------------------------
-    yield _format_sse(
-        QuickSimEvent(
-            event="done",
-            data={
-                "completed": completed,
-                "errored": errored,
-                "total": len(request.opportunities),
-            },
-            request_context=request.request_context,
-        )
+    return QuickSimBatchResponse(
+        tdfs=entries,
+        completed=completed,
+        errored=errored,
+        total=len(request.opportunities),
+        request_context=request.request_context,
     )
 
 
@@ -566,8 +536,8 @@ async def quick_sim_batch(
     request: Request,
     user: User | None = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
-) -> StreamingResponse:
-    """Stream future-moment TDFs + quick-sim metrics for a batch of opportunities.
+) -> QuickSimBatchResponse:
+    """Return future-moment TDFs + quick-sim metrics for a batch of opportunities.
 
     For each opportunity (1–15) provided, this:
 
@@ -575,11 +545,18 @@ async def quick_sim_batch(
     2. Runs the standard 14-agent ``GenerationPipeline`` to produce a
        future-moment TDF.
     3. Runs a single :class:`QuickSimMetricsAgent` LLM call to extract
-       ``probability_of_award``, ``fit_score``, ``effort_estimate``,
-       ``key_risks``, and ``key_levers``.
-    4. Streams an ``opportunity_complete`` (or ``opportunity_error``)
-       SSE event as soon as that opportunity finishes — the web app can
-       render selection cards progressively.
+       ``probability_of_award``, ``fit_score``, ``effort_score``,
+       ``effort_estimate``, ``key_risks``, and ``key_levers``.
+    4. Folds the result into a :class:`QuickSimTdfEntry`.
+
+    Response:
+        A single ``application/json`` :class:`QuickSimBatchResponse`
+        (HTTP 200) — **not** an SSE stream. The consumer is the
+        web-app's ``run_quick_sim`` background job, and the API gateway
+        cannot proxy ``text/event-stream``. ``tdfs`` carries one entry
+        per opportunity (including failures, flagged
+        ``source="flash-quick-sim-error"``) so the list pairs 1:1 with
+        the request.
 
     Billing:
         Per-opportunity, using the ``quick_sim_per_opportunity`` cost
@@ -588,20 +565,14 @@ async def quick_sim_batch(
         all per-opportunity charges so the Gateway can meter at the
         batch level instead.
 
-    Response:
-        ``text/event-stream`` of :class:`QuickSimEvent` events:
-        ``start`` → ``opportunity_complete`` × N (interleaved with any
-        ``opportunity_error`` events) → ``done``.
-
     Args:
         body: :class:`QuickSimBatchRequest`.
-        request: Raw FastAPI request (used for disconnect detection and
-            the gateway-metered header).
+        request: Raw FastAPI request (used for the gateway-metered header).
         user: Authenticated user (or None when AUTH_ENABLED=false).
         session: DB session for credit ledger writes.
 
     Returns:
-        ``StreamingResponse`` with ``text/event-stream`` content type.
+        :class:`QuickSimBatchResponse` serialised as JSON with HTTP 200.
     """
     gateway_metered = request.headers.get(_GATEWAY_METERED_HEADER, "").lower() == "true"
 
@@ -614,18 +585,17 @@ async def quick_sim_batch(
         body.preset,
     )
 
-    return StreamingResponse(
-        _stream_batch(
-            request=body,
-            user=user,
-            session=session,
-            gateway_metered=gateway_metered,
-            disconnect_check=request.is_disconnected,
-        ),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # disable nginx buffering
-        },
+    response = await _run_batch(
+        request=body,
+        user=user,
+        session=session,
+        gateway_metered=gateway_metered,
     )
+
+    logger.info(
+        "quick_sim_batch: done completed=%d errored=%d total=%d",
+        response.completed,
+        response.errored,
+        response.total,
+    )
+    return response

--- a/app/prompts/quick_sim.py
+++ b/app/prompts/quick_sim.py
@@ -114,6 +114,13 @@ You produce a structured fit assessment with five fields:
   ~0.5. A loose-shape grant for the right amount is ~0.4. Misaligned timing
   or eligibility caps this below 0.3.
 
+- effort_score (0.0-1.0): Normalised effort to pursue this opportunity, where
+  higher means more work. 0.0-0.3 = a light-touch application (a few hours, a
+  short form); 0.4-0.6 = a moderate proposal (a couple of days, a narrative +
+  one or two artefacts); 0.7-1.0 = a heavy full submission (a week or more,
+  full proposal, budget, references, site visit). This MUST be consistent with
+  effort_estimate.
+
 - effort_estimate: One short phrase. Examples: "low — 4h application",
   "moderate — 20h proposal + 1 reference letter", "high — 60h full proposal,
   budget, and site visit". Be concrete about hours and artefacts.
@@ -153,6 +160,7 @@ Respond with valid JSON matching this schema:
 {{
   "probability_of_award": 0.0-1.0,
   "fit_score": 0.0-1.0,
+  "effort_score": 0.0-1.0,
   "effort_estimate": "short phrase with hours",
   "key_risks": ["risk 1", "risk 2", "..."],
   "key_levers": ["lever 1", "lever 2", "..."],

--- a/app/schemas/quick_sim.py
+++ b/app/schemas/quick_sim.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class OpportunityIn(BaseModel):
@@ -42,19 +42,34 @@ class OpportunityIn(BaseModel):
     fields except ``title`` are optional — the LLM is robust to missing
     data, and the caller may have varying-quality results.
 
+    The web-app sourcing stage (``app/find_money/runs/jobs.py``) emits
+    opportunity stubs keyed ``url`` / ``amount_usd``; this endpoint's
+    own spec uses ``source_url`` / ``amount``. Both spellings are
+    accepted on input via validation aliases so the cross-service
+    contract works regardless of which side names the field.
+
     Attributes:
         title: Short opportunity name (required).
         source_url: Canonical URL for the opportunity (optional).
+            Accepts ``url`` as an alias.
         summary: Short prose description (optional).
         amount: Dollar amount available, as a number or human string
-            ("$10k–$50k", "up to $25,000", 50000).
+            ("$10k–$50k", "up to $25,000", 50000). Accepts ``amount_usd``
+            as an alias.
         deadline: Application/award deadline as ISO date or human string.
     """
 
     title: str = Field(..., min_length=1, max_length=300)
-    source_url: str | None = Field(default=None, max_length=2000)
+    source_url: str | None = Field(
+        default=None,
+        max_length=2000,
+        validation_alias=AliasChoices("source_url", "url"),
+    )
     summary: str | None = Field(default=None, max_length=4000)
-    amount: float | int | str | None = Field(default=None)
+    amount: float | int | str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("amount", "amount_usd"),
+    )
     deadline: str | None = Field(default=None, max_length=200)
 
 
@@ -101,6 +116,10 @@ class QuickSimMetrics(BaseModel):
             opportunity if they pursue it.
         fit_score: Alignment (0–1) between the user's goal and what the
             opportunity actually funds.
+        effort_score: Normalised effort to pursue this opportunity (0–1,
+            higher = more work). 0.0–0.3 is a light-touch application,
+            0.4–0.6 a moderate proposal, 0.7–1.0 a heavy full submission.
+            The web-app selection page ranks on this numeric field.
         effort_estimate: Short prose estimate of work required
             ("low — 4h application", "high — 60h proposal + budget").
         key_risks: 1–5 short risk bullets (selection criteria, timing,
@@ -113,7 +132,84 @@ class QuickSimMetrics(BaseModel):
 
     probability_of_award: float = Field(..., ge=0.0, le=1.0)
     fit_score: float = Field(..., ge=0.0, le=1.0)
+    effort_score: float = Field(..., ge=0.0, le=1.0)
     effort_estimate: str = Field(..., min_length=1, max_length=500)
     key_risks: list[str] = Field(default_factory=list, max_length=5)
     key_levers: list[str] = Field(default_factory=list, max_length=5)
     rationale: str | None = Field(default=None, max_length=800)
+
+
+class QuickSimTdfEntry(BaseModel):
+    """One entry in the quick-sim-batch JSON response — one per opportunity.
+
+    The flat ``tdf_ref`` / ``opportunity_index`` / ``title`` / ``url`` /
+    ``summary`` / ``probability`` / ``fit_score`` / ``effort_score`` /
+    ``amount_usd`` / ``source`` fields match the shape the web-app's
+    Find Money pipeline pairs against (``_seed_quick_sim_tdfs`` in
+    ``app/find_money/runs/jobs.py``), so real Flash output and the
+    web-app seed fallback are interchangeable to the selection page.
+
+    The richer ``tdf`` / ``quick_sim`` payloads are carried through for
+    the downstream Pro deep-sim and result page; the web-app forwards
+    each entry dict wholesale, so extra keys are harmless.
+
+    Attributes:
+        tdf_ref: Stable per-entry reference (``flash:quick:{index}``).
+        opportunity_index: Zero-based index matching request order.
+        title: Opportunity title (echoed from the request stub).
+        url: Opportunity source URL, if any.
+        summary: Opportunity summary, if any.
+        probability: ``probability_of_award`` from the metrics agent,
+            or ``None`` when the opportunity failed.
+        fit_score: ``fit_score`` from the metrics agent, or ``None``.
+        effort_score: ``effort_score`` from the metrics agent, or ``None``.
+        amount_usd: Opportunity amount (number or free-text), if any.
+        source: ``"flash-quick-sim"`` on success,
+            ``"flash-quick-sim-error"`` when the opportunity failed.
+        tdf: Full future-moment TDF payload (``None`` on failure or when
+            the scene pipeline produced nothing).
+        quick_sim: Full :class:`QuickSimMetrics` (``None`` on failure).
+        error: Failure message (``None`` on success).
+        latency_ms: Wall-clock time for this opportunity.
+    """
+
+    tdf_ref: str
+    opportunity_index: int
+    title: str
+    url: str | None = None
+    summary: str | None = None
+    probability: float | None = None
+    fit_score: float | None = None
+    effort_score: float | None = None
+    amount_usd: float | int | str | None = None
+    source: str
+    tdf: dict[str, Any] | None = None
+    quick_sim: QuickSimMetrics | None = None
+    error: str | None = None
+    latency_ms: int = 0
+
+
+class QuickSimBatchResponse(BaseModel):
+    """JSON response body for POST /api/v1/find-money/quick-sim-batch.
+
+    This endpoint returns a single JSON object (HTTP 200), **not** an
+    SSE stream — the consumer is a server-side background job
+    (``run_quick_sim`` in the web-app), and the API gateway cannot proxy
+    ``text/event-stream`` responses.
+
+    Attributes:
+        tdfs: One :class:`QuickSimTdfEntry` per requested opportunity,
+            ordered by ``opportunity_index``. Includes failed
+            opportunities (with ``source == "flash-quick-sim-error"``)
+            so the list always pairs 1:1 with the request.
+        completed: Count of opportunities that simulated successfully.
+        errored: Count of opportunities that failed.
+        total: Total opportunities in the request.
+        request_context: Opaque context echoed back from the request.
+    """
+
+    tdfs: list[QuickSimTdfEntry]
+    completed: int
+    errored: int
+    total: int
+    request_context: dict[str, Any] | None = None

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -1,36 +1,47 @@
 """Unit tests for /api/v1/find-money/quick-sim-batch.
 
 These tests cover:
-- Request schema validation (size limits, required fields)
+- Request schema validation (size limits, required fields, input aliases)
 - Future-moment query builder (length cap, missing fields handled)
 - TDF → metrics-prompt summariser (degrades gracefully)
-- SSE format helper
-- Endpoint route registration
+- Response shape: ``QuickSimTdfEntry`` / ``QuickSimBatchResponse`` (the
+  ``{"tdfs": [...]}`` JSON contract the web-app pairs against — NOT SSE)
+- A **real** ``GenerationPipeline`` integration check: the handler builds
+  every pipeline through ``_build_generation_pipeline``; constructing a
+  real pipeline through that seam here fails CI on an ``__init__``
+  signature drift. PR #45 shipped a runtime crash
+  (``TypeError: GenerationPipeline.__init__() got an unexpected keyword
+  argument 'user_id'``) precisely because its tests never built a real
+  pipeline — this file closes that gap.
 
-The pipeline + LLM calls themselves are NOT exercised here (those live
-under ``tests/e2e``); per the no-mocks rule we don't fake them. The
-endpoint is exercised end-to-end against a live preset in
-``tests/e2e/test_find_money_quick_sim.py`` (gated on real API keys).
+Per ``feedback_no_mocks.md`` nothing here is mocked. The pipeline's live
+LLM calls are not exercised (those need real API keys / a live preset);
+the integration test stops at construction, which is exactly where the
+shipped signature bug lived.
 """
 
 from __future__ import annotations
 
-import json
+import inspect
 
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from app.api.v1.find_money import (
-    QuickSimEvent,
-    _format_sse,
+    _build_generation_pipeline,
+    _build_tdf_entry,
     summarize_tdf_for_metrics,
 )
+from app.config import QualityPreset
+from app.core.pipeline import GenerationPipeline
 from app.prompts.quick_sim import build_future_moment_query
 from app.schemas.quick_sim import (
     OpportunityIn,
     QuickSimBatchRequest,
+    QuickSimBatchResponse,
     QuickSimMetrics,
+    QuickSimTdfEntry,
 )
 
 # ---------------------------------------------------------------------------
@@ -64,6 +75,28 @@ class TestOpportunityIn:
         """Amount can be a free-text string like '$10k–$50k'."""
         opp = OpportunityIn(title="x", amount="$10k–$50k")
         assert opp.amount == "$10k–$50k"
+
+    def test_accepts_web_app_url_and_amount_usd_aliases(self):
+        """The web-app sourcing stage emits ``url`` / ``amount_usd`` keys.
+
+        ``OpportunityIn`` accepts those as validation aliases so the
+        cross-service request contract works regardless of which side
+        names the field.
+        """
+        opp = OpportunityIn.model_validate(
+            {
+                "title": "Climate Action Fund",
+                "url": "https://example.org/climate",
+                "amount_usd": 25000,
+                "summary": "Annual climate grants",
+            }
+        )
+        assert opp.source_url == "https://example.org/climate"
+        assert opp.amount == 25000
+        # Canonical field names survive a round-trip dump.
+        dumped = opp.model_dump()
+        assert dumped["source_url"] == "https://example.org/climate"
+        assert dumped["amount"] == 25000
 
     def test_title_required(self):
         with pytest.raises(ValidationError):
@@ -123,6 +156,7 @@ class TestQuickSimMetrics:
         m = QuickSimMetrics(
             probability_of_award=0.42,
             fit_score=0.7,
+            effort_score=0.55,
             effort_estimate="moderate — 20h proposal",
             key_risks=["competitive field"],
             key_levers=["co-applicant from anchor org"],
@@ -130,6 +164,7 @@ class TestQuickSimMetrics:
         )
         assert m.probability_of_award == pytest.approx(0.42)
         assert m.fit_score == pytest.approx(0.7)
+        assert m.effort_score == pytest.approx(0.55)
         assert m.key_risks == ["competitive field"]
 
     def test_probability_bounds(self):
@@ -137,12 +172,14 @@ class TestQuickSimMetrics:
             QuickSimMetrics(
                 probability_of_award=1.1,
                 fit_score=0.5,
+                effort_score=0.5,
                 effort_estimate="x",
             )
         with pytest.raises(ValidationError):
             QuickSimMetrics(
                 probability_of_award=-0.1,
                 fit_score=0.5,
+                effort_score=0.5,
                 effort_estimate="x",
             )
 
@@ -151,13 +188,40 @@ class TestQuickSimMetrics:
             QuickSimMetrics(
                 probability_of_award=0.5,
                 fit_score=1.5,
+                effort_score=0.5,
                 effort_estimate="x",
             )
+
+    def test_effort_score_bounds(self):
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=0.5,
+                fit_score=0.5,
+                effort_score=1.5,
+                effort_estimate="x",
+            )
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=0.5,
+                fit_score=0.5,
+                effort_score=-0.1,
+                effort_estimate="x",
+            )
+
+    def test_effort_score_required(self):
+        """effort_score is required — the web-app selection page ranks on it."""
+        with pytest.raises(ValidationError):
+            QuickSimMetrics(
+                probability_of_award=0.5,
+                fit_score=0.5,
+                effort_estimate="x",
+            )  # type: ignore[call-arg]
 
     def test_default_empty_lists(self):
         m = QuickSimMetrics(
             probability_of_award=0.5,
             fit_score=0.5,
+            effort_score=0.5,
             effort_estimate="x",
         )
         assert m.key_risks == []
@@ -320,35 +384,217 @@ class TestSummarizeTdfForMetrics:
 
 
 # ---------------------------------------------------------------------------
-# SSE format helper
+# Real GenerationPipeline integration — catches __init__ signature drift
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.fast
-class TestFormatSse:
-    """Tests for the SSE wire-format helper."""
+class TestGenerationPipelineIntegration:
+    """Construct a real GenerationPipeline through the handler's seam.
 
-    def test_emits_sse_data_line(self):
-        line = _format_sse(QuickSimEvent(event="start"))
-        assert line.startswith("data: ")
-        assert line.endswith("\n\n")
+    The handler builds every pipeline via
+    :func:`app.api.v1.find_money._build_generation_pipeline`. These tests
+    call that exact function with the exact kwargs the handler passes,
+    so an ``__init__`` signature regression fails CI here rather than at
+    runtime in production.
 
-    def test_payload_is_valid_json(self):
-        line = _format_sse(
-            QuickSimEvent(
-                event="opportunity_complete",
-                index=0,
-                opportunity={"title": "x"},
-                data={"latency_ms": 1234},
-            )
+    This is the gap that let PR #45 ship
+    ``TypeError: GenerationPipeline.__init__() got an unexpected keyword
+    argument 'user_id'`` — its unit tests validated schemas but never
+    built a real pipeline. Nothing here is mocked; construction is real,
+    and it stops before the live LLM call (which needs real API keys).
+    """
+
+    def test_build_generation_pipeline_constructs_real_pipeline(self):
+        """The handler seam builds a real GenerationPipeline with its kwargs.
+
+        Fails if ``GenerationPipeline.__init__`` drops or renames
+        ``preset`` / ``user_id`` / ``entity_ids`` — i.e. the exact
+        regression PR #45 shipped.
+        """
+        pipeline = _build_generation_pipeline(
+            preset=QualityPreset.HYPER,
+            user_id="user-abc123",
+            entity_ids=["clockchain-figure-1"],
         )
-        # Strip the prefix and trailing newlines, then parse JSON.
-        payload = line[len("data: ") :].strip()
-        decoded = json.loads(payload)
-        assert decoded["event"] == "opportunity_complete"
-        assert decoded["index"] == 0
-        assert decoded["opportunity"] == {"title": "x"}
-        assert decoded["data"]["latency_ms"] == 1234
+        assert isinstance(pipeline, GenerationPipeline)
+        # The kwargs must actually land on the object, not just be accepted.
+        assert pipeline._user_id == "user-abc123"
+        assert pipeline._preset == QualityPreset.HYPER
+        assert pipeline._entity_ids == ["clockchain-figure-1"]
+
+    def test_build_generation_pipeline_with_minimal_kwargs(self):
+        """Anonymous (AUTH_ENABLED=false) requests pass user_id=None."""
+        pipeline = _build_generation_pipeline(preset=None, user_id=None)
+        assert isinstance(pipeline, GenerationPipeline)
+        assert pipeline._user_id is None
+
+    def test_generation_pipeline_signature_accepts_quick_sim_kwargs(self):
+        """Explicit signature guard: GenerationPipeline must accept these kwargs.
+
+        Belt-and-suspenders alongside the construction test — names the
+        contract the Find Money handler depends on so a future signature
+        change is an obvious, self-documenting CI failure.
+        """
+        params = inspect.signature(GenerationPipeline.__init__).parameters
+        for kw in ("preset", "user_id", "entity_ids"):
+            assert kw in params, (
+                f"GenerationPipeline.__init__ no longer accepts '{kw}' — "
+                "the Find Money quick-sim handler passes it."
+            )
+
+    def test_simulate_one_builds_through_the_seam(self):
+        """_simulate_one must construct its pipeline via _build_generation_pipeline.
+
+        Guards the wiring: if a refactor reintroduces a direct
+        ``GenerationPipeline(...)`` call in ``_simulate_one``, the
+        construction test above stops covering the real handler path.
+        """
+        from app.api.v1 import find_money as fm
+
+        source = inspect.getsource(fm._simulate_one)
+        assert "_build_generation_pipeline(" in source
+        assert "GenerationPipeline(" not in source
+
+
+# ---------------------------------------------------------------------------
+# Response shape — QuickSimTdfEntry / QuickSimBatchResponse (JSON, not SSE)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestBuildTdfEntry:
+    """`_build_tdf_entry` folds a sim result into the web-app's entry shape.
+
+    The flat key set must match what
+    ``timepoint-web-app/app/find_money/runs/jobs.py::_seed_quick_sim_tdfs``
+    produces, so real Flash output and the web-app seed fallback are
+    interchangeable to the selection page.
+    """
+
+    # The exact flat shape the web-app pairs against.
+    _CANONICAL_KEYS = {
+        "tdf_ref",
+        "opportunity_index",
+        "title",
+        "url",
+        "summary",
+        "probability",
+        "fit_score",
+        "effort_score",
+        "amount_usd",
+        "source",
+    }
+
+    def _opportunity(self) -> OpportunityIn:
+        return OpportunityIn(
+            title="Climate Action Fund",
+            source_url="https://example.org/climate",
+            summary="Annual $10-50k grants for climate work",
+            amount=25000,
+        )
+
+    def test_success_entry_has_canonical_shape(self):
+        metrics = QuickSimMetrics(
+            probability_of_award=0.18,
+            fit_score=0.62,
+            effort_score=0.5,
+            effort_estimate="moderate — 20h proposal",
+            key_risks=["tight deadline"],
+            key_levers=["warm intro"],
+            rationale="strong fit, crowded pool",
+        )
+        result = {
+            "success": True,
+            "tdf": {"scene_data": {"setting": "boardroom"}},
+            "quick_sim": metrics,
+            "error": None,
+            "latency_ms": 42000,
+        }
+        entry = _build_tdf_entry(index=7, opportunity=self._opportunity(), result=result)
+
+        assert isinstance(entry, QuickSimTdfEntry)
+        dumped = entry.model_dump()
+        # Every web-app-required key is present.
+        assert self._CANONICAL_KEYS <= set(dumped)
+        assert entry.tdf_ref == "flash:quick:7"
+        assert entry.opportunity_index == 7
+        assert entry.title == "Climate Action Fund"
+        assert entry.url == "https://example.org/climate"
+        assert entry.summary == "Annual $10-50k grants for climate work"
+        assert entry.probability == pytest.approx(0.18)
+        assert entry.fit_score == pytest.approx(0.62)
+        assert entry.effort_score == pytest.approx(0.5)
+        assert entry.amount_usd == 25000
+        assert entry.source == "flash-quick-sim"
+        assert entry.error is None
+        # Rich payload is carried through for the downstream Pro deep-sim.
+        assert entry.tdf == {"scene_data": {"setting": "boardroom"}}
+        assert entry.quick_sim is metrics
+        assert entry.latency_ms == 42000
+
+    def test_error_entry_has_canonical_shape_with_null_metrics(self):
+        """Failed opportunities still produce one entry — null scores, flagged source."""
+        result = {
+            "success": False,
+            "tdf": None,
+            "quick_sim": None,
+            "error": "quick_sim timed out after 120s",
+            "latency_ms": 120100,
+        }
+        entry = _build_tdf_entry(index=3, opportunity=self._opportunity(), result=result)
+
+        dumped = entry.model_dump()
+        assert self._CANONICAL_KEYS <= set(dumped)
+        assert entry.tdf_ref == "flash:quick:3"
+        assert entry.opportunity_index == 3
+        assert entry.probability is None
+        assert entry.fit_score is None
+        assert entry.effort_score is None
+        assert entry.source == "flash-quick-sim-error"
+        assert entry.error == "quick_sim timed out after 120s"
+        assert entry.tdf is None
+        assert entry.quick_sim is None
+
+    def test_amount_passthrough_for_string_amount(self):
+        opp = OpportunityIn(title="x", amount="$10k–$50k")
+        result = {"success": False, "tdf": None, "quick_sim": None, "error": "e"}
+        entry = _build_tdf_entry(index=0, opportunity=opp, result=result)
+        assert entry.amount_usd == "$10k–$50k"
+
+
+@pytest.mark.fast
+class TestQuickSimBatchResponse:
+    """The batch response is a single JSON object — ``{"tdfs": [...]}`` — not SSE."""
+
+    def test_response_serialises_tdfs_as_list(self):
+        entry = QuickSimTdfEntry(
+            tdf_ref="flash:quick:0",
+            opportunity_index=0,
+            title="Climate Action Fund",
+            source="flash-quick-sim",
+        )
+        resp = QuickSimBatchResponse(
+            tdfs=[entry],
+            completed=1,
+            errored=0,
+            total=1,
+            request_context={"run_id": "fm-run-1"},
+        )
+        dumped = resp.model_dump()
+        assert isinstance(dumped["tdfs"], list)
+        assert dumped["tdfs"][0]["tdf_ref"] == "flash:quick:0"
+        assert dumped["completed"] == 1
+        assert dumped["total"] == 1
+        assert dumped["request_context"] == {"run_id": "fm-run-1"}
+
+    def test_json_round_trip(self):
+        """The response is plain JSON the web-app can ``r.json()`` directly."""
+        resp = QuickSimBatchResponse(tdfs=[], completed=0, errored=0, total=0)
+        raw = resp.model_dump_json()
+        reparsed = QuickSimBatchResponse.model_validate_json(raw)
+        assert reparsed.tdfs == []
+        assert reparsed.total == 0
 
 
 # ---------------------------------------------------------------------------
@@ -366,34 +612,58 @@ def client():
 
 @pytest.mark.fast
 class TestEndpointRegistered:
-    """The endpoint must be registered under /api/v1/find-money/quick-sim-batch."""
+    """The endpoint must be a registered, JSON (non-SSE) POST route."""
+
+    _PATH = "/api/v1/find-money/quick-sim-batch"
 
     def test_route_is_registered(self):
         from app.main import app
 
         paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
         # FastAPI's APIRouter combines parent prefix with the route path.
-        assert "/api/v1/find-money/quick-sim-batch" in paths
+        assert self._PATH in paths
+
+    def test_route_returns_json_batch_response_not_sse(self):
+        """The route's response_model is QuickSimBatchResponse — a JSON body.
+
+        This is the structural guarantee that the endpoint no longer
+        streams ``text/event-stream`` (which the API gateway 502s on and
+        the web-app's ``r.json()`` consumer cannot parse).
+        """
+        from app.main import app
+        from app.schemas.quick_sim import QuickSimBatchResponse as _Resp
+
+        route = next(
+            r
+            for r in app.routes
+            if getattr(r, "path", None) == self._PATH  # type: ignore[attr-defined]
+        )
+        assert route.response_model is _Resp  # type: ignore[attr-defined]
+        # SSE was the old contract — the helpers that built it are gone.
+        from app.api.v1 import find_money as fm
+
+        assert not hasattr(fm, "_format_sse")
+        assert not hasattr(fm, "QuickSimEvent")
 
     def test_get_returns_405(self, client):
         """GET is not allowed — only POST."""
-        resp = client.get("/api/v1/find-money/quick-sim-batch")
+        resp = client.get(self._PATH)
         assert resp.status_code in (404, 405)
 
     def test_empty_body_returns_422(self, client):
-        resp = client.post("/api/v1/find-money/quick-sim-batch", json={})
+        resp = client.post(self._PATH, json={})
         assert resp.status_code == 422
 
     def test_empty_opportunities_returns_422(self, client):
         resp = client.post(
-            "/api/v1/find-money/quick-sim-batch",
+            self._PATH,
             json={"goal": "valid goal", "opportunities": []},
         )
         assert resp.status_code == 422
 
     def test_too_many_opportunities_returns_422(self, client):
         resp = client.post(
-            "/api/v1/find-money/quick-sim-batch",
+            self._PATH,
             json={
                 "goal": "valid goal",
                 "opportunities": [{"title": f"opp {i}"} for i in range(16)],
@@ -403,7 +673,7 @@ class TestEndpointRegistered:
 
     def test_goal_too_short_returns_422(self, client):
         resp = client.post(
-            "/api/v1/find-money/quick-sim-batch",
+            self._PATH,
             json={
                 "goal": "ab",
                 "opportunities": [{"title": "opp 1"}],


### PR DESCRIPTION
Closes el-155tv. Fixes two contract bugs in POST /api/v1/find-money/quick-sim-batch.

1. Returns a single JSON QuickSimBatchResponse ({tdfs:[...], completed, errored, total, request_context}, HTTP 200) instead of SSE. Each tdfs entry matches the web-app consumer's flat shape (tdf_ref, opportunity_index, title, url, summary, probability, fit_score, effort_score, amount_usd, source) + carries full tdf/quick_sim payloads for Pro deep-sim. One entry per opportunity including failures. SSE machinery removed. (The gateway 502d on the SSE stream; web-app's _flash_quick_sim_batch does r.json() — both now satisfied.)
2. Confirmed upstream GenerationPipeline.__init__ accepts user_id/entity_ids/preset (post-a1329e1) — no upstream bug; the prod crash is purely deploy-private drift (el-26qqm). Construction routes through a _build_generation_pipeline seam.
3. Real integration test (TestGenerationPipelineIntegration) constructs a real GenerationPipeline via that seam with the handler's exact kwargs — fails CI on __init__ signature drift, which is the test gap that let the original crash ship. No mocks, stops before the live LLM call. Plus an inspect.signature guard + a wiring guard.
4. Per-opportunity credit metering + refund-on-failure preserved.

Extra (in-scope): added numeric effort_score (0-1) to QuickSimMetrics + metrics prompt — the web-app selection page ranks on it but the SSE spec only had prose effort_estimate. And OpportunityIn now accepts web-app's url/amount_usd keys as validation aliases for source_url/amount (same class of shape-mismatch bug, request side).

Tests: 693 fast tests pass (47 in test_api_find_money.py), ruff clean. Spec doc el-4myis updated to v2.

Deploy-private sync to prod is el-26qqm (separate task).