### PR TITLE
perf(find-money): reduce Gemini structured-output latency floor (el-4qrlp)

### DIFF
--- a/app/agents/quick_sim.py
+++ b/app/agents/quick_sim.py
@@ -32,6 +32,10 @@ from app.core.llm_router import LLMRouter
 from app.prompts import quick_sim as quick_sim_prompts
 from app.schemas.quick_sim import QuickSimMetrics
 
+# Quick-sim runs the metrics call at a low, fixed sampling temperature so
+# calibration stays stable across a batch.
+_METRICS_TEMPERATURE = 0.3
+
 
 @dataclass
 class QuickSimMetricsInput:
@@ -63,8 +67,25 @@ class QuickSimMetricsAgent(BaseAgent[QuickSimMetricsInput, QuickSimMetrics]):
 
     response_model = QuickSimMetrics
 
-    def __init__(self, router: LLMRouter | None = None) -> None:
-        super().__init__(router=router, name="QuickSimMetricsAgent")
+    def __init__(
+        self,
+        router: LLMRouter | None = None,
+        llm_params: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialise the metrics agent.
+
+        Args:
+            router: Shared LLM router (quick-sim passes the pipeline's
+                router so the metrics call reuses the same fast,
+                Google-native text path).
+            llm_params: Per-call LLM params (e.g. ``thinking_level``,
+                ``max_tokens``). Quick-sim forwards its tuning here so the
+                metrics call gets the same capped thinking budget as the
+                scene pipeline — without it, the metrics call falls back
+                to ``gemini-2.5-flash``'s dynamic thinking budget and
+                becomes the slowest step in the per-opportunity path.
+        """
+        super().__init__(router=router, name="QuickSimMetricsAgent", llm_params=llm_params)
 
     def get_system_prompt(self) -> str:
         return quick_sim_prompts.get_metrics_system_prompt()
@@ -85,4 +106,4 @@ class QuickSimMetricsAgent(BaseAgent[QuickSimMetricsInput, QuickSimMetrics]):
         Returns:
             AgentResult with QuickSimMetrics on success, error otherwise.
         """
-        return await self._call_llm(input_data, temperature=0.3)
+        return await self._call_llm(input_data, temperature=_METRICS_TEMPERATURE)

--- a/app/agents/quick_sim.py
+++ b/app/agents/quick_sim.py
@@ -78,12 +78,11 @@ class QuickSimMetricsAgent(BaseAgent[QuickSimMetricsInput, QuickSimMetrics]):
             router: Shared LLM router (quick-sim passes the pipeline's
                 router so the metrics call reuses the same fast,
                 Google-native text path).
-            llm_params: Per-call LLM params (e.g. ``thinking_level``,
-                ``max_tokens``). Quick-sim forwards its tuning here so the
-                metrics call gets the same capped thinking budget as the
-                scene pipeline — without it, the metrics call falls back
-                to ``gemini-2.5-flash``'s dynamic thinking budget and
-                becomes the slowest step in the per-opportunity path.
+            llm_params: Per-call LLM params (e.g. ``max_tokens``).
+                Quick-sim forwards its output cap here so the metrics call
+                uses the same bounded output as the scene pipeline.
+                The quick-sim path uses ``gemini-2.0-flash`` (non-thinking),
+                so no ``thinking_level`` is needed or valid.
         """
         super().__init__(router=router, name="QuickSimMetricsAgent", llm_params=llm_params)
 

--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -109,32 +109,30 @@ _BATCH_CONCURRENCY = 6
 # per-opportunity pipeline to the fastest *reliable* text path instead of
 # trusting the request's ``preset``:
 #
-#   * Model: ``gemini-2.5-flash``, called Google-native. The ``hyper``
-#     preset's ``google/gemini-2.0-flash-001`` routes through OpenRouter,
-#     whose shared upstream account is chronically 429 rate-limited (see
-#     ``project_openrouter_keys.md``) — every call eats a ~7s rate-limit
-#     round-trip before falling back. Google-native ``gemini-2.5-flash``
-#     answers a structured call in ~1-2s. ``gemini-2.5-flash`` is
-#     ``VerifiedModels.GOOGLE_TEXT[0]``, so it always passes preset
-#     validation.
-#   * Thinking: capped to a small fixed budget (``thinking_level=512``).
-#     ``gemini-2.5-flash`` defaults to a *dynamic* thinking budget; on a
-#     JSON-schema structured call it burns 5-10s "thinking" for a
-#     sub-1k-token answer. A small fixed budget keeps each call to ~1-3s
-#     while still leaving the Judge agent enough reasoning room to
-#     classify the future-moment framing query as valid (a hard ``0``
-#     budget makes the Judge reject it). ``thinking_level`` is forwarded
-#     to the Google provider as ``ThinkingConfig.thinking_budget``.
+#   * Model: ``gemini-2.0-flash``, called Google-native. This replaces the
+#     original ``gemini-2.5-flash`` choice after investigation task
+#     el-4qrlp measured a median 8.1s/call floor on 74 structured-output
+#     samples with ``gemini-2.5-flash`` (thinking_level=512). Reducing the
+#     thinking budget from 512 to 128 made no measurable difference, ruling
+#     out thinking-token count as the bottleneck. Root cause: ``gemini-2.5-flash``
+#     is a thinking-capable architecture with a fixed inference-time overhead
+#     that cannot be eliminated by capping the budget. ``gemini-2.0-flash`` is
+#     a non-thinking model (``supports_extended_thinking=False`` in the
+#     model registry) so zero thinking tokens are spent per call. Expected
+#     improvement: ~8s median -> ~2-4s per call, enabling the "15 opps inside
+#     60s" product target. ``gemini-2.0-flash`` is ``VerifiedModels.GOOGLE_TEXT[1]``,
+#     supports ``response_schema`` (``supports_json_schema=True``), and is
+#     called Google-native (not via OpenRouter, which is 429 rate-limited).
 #   * Output cap: ``max_tokens`` kept generous-but-bounded; the quick-sim
-#     agents emit small structured payloads (largest observed ~850
-#     tokens), so 4096 is plenty of headroom without inviting runaway
-#     generations.
+#     agents emit small structured payloads (largest observed ~850 tokens),
+#     so 4096 is plenty of headroom without inviting runaway generations.
+#     No ``thinking_level`` is needed or valid for a non-thinking model.
 #
 # The ``preset`` the caller passes still flows through (it selects the
-# parallelism mode), but the text model + thinking config below override
-# it so quick-sim stays fast regardless of which preset the web-app sends.
-_QUICK_SIM_TEXT_MODEL = "gemini-2.5-flash"
-_QUICK_SIM_LLM_PARAMS: dict[str, Any] = {"thinking_level": 512, "max_tokens": 4096}
+# parallelism mode), but the text model + output cap below override it so
+# quick-sim stays fast regardless of which preset the web-app sends.
+_QUICK_SIM_TEXT_MODEL = "gemini-2.0-flash"
+_QUICK_SIM_LLM_PARAMS: dict[str, Any] = {"max_tokens": 4096}
 
 
 # ---------------------------------------------------------------------------
@@ -181,9 +179,9 @@ def _build_generation_pipeline(
             :data:`_QUICK_SIM_TEXT_MODEL` so the per-opportunity pipeline
             uses the fast Google-native path rather than the request
             preset's (possibly rate-limited) model.
-        llm_params: Optional per-call LLM params (e.g. ``thinking_level``,
-            ``max_tokens``). Quick-sim passes :data:`_QUICK_SIM_LLM_PARAMS`
-            to disable extended thinking and bound output.
+        llm_params: Optional per-call LLM params (e.g. ``max_tokens``).
+            Quick-sim passes :data:`_QUICK_SIM_LLM_PARAMS` to bound
+            output length.
 
     Returns:
         A ready-to-run :class:`GenerationPipeline`.
@@ -333,7 +331,7 @@ async def _simulate_one(
         # LIGHT path: run_quick_sim runs only Judge -> Timeline -> Scene ->
         # CharacterIdentification -> Moment (five LLM calls), not the full
         # ~14-agent render — and the pipeline is pinned to the fast
-        # Google-native text path with the thinking budget capped. Together
+        # Google-native gemini-2.0-flash path (non-thinking model). Together
         # these keep a single opportunity to a few seconds instead of >90s.
         state = await asyncio.wait_for(
             pipeline.run_quick_sim(query),
@@ -349,9 +347,8 @@ async def _simulate_one(
         scene_context = summarize_tdf_for_metrics(tdf)
 
         # The metrics agent reuses the pipeline's router (same fast,
-        # Google-native text path) AND the same capped thinking budget —
-        # without _QUICK_SIM_LLM_PARAMS it would fall back to the model's
-        # dynamic thinking budget and become the slowest step in the path.
+        # Google-native gemini-2.0-flash path) and the same output cap —
+        # the non-thinking model incurs no thinking overhead on any call.
         metrics_agent = QuickSimMetricsAgent(
             router=pipeline.router,
             llm_params=dict(_QUICK_SIM_LLM_PARAMS),

--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -8,10 +8,17 @@ Money pipeline (``run_quick_sim`` in
 background job, not a browser, so there is no value in streaming, and
 the API gateway cannot proxy ``text/event-stream`` responses.
 
-This module deliberately reuses the existing 14-agent
-:class:`app.core.pipeline.GenerationPipeline` for scene generation —
-the only new model call is the small :class:`QuickSimMetricsAgent` that
-extracts the structured fit fields after each scene completes.
+This module reuses the existing :class:`app.core.pipeline.GenerationPipeline`,
+but drives it through its LIGHT entry point
+(:meth:`~app.core.pipeline.GenerationPipeline.run_quick_sim`) rather than
+the full ~14-agent render. Quick-sim is a fast first-pass read, so the
+pipeline is parameterized down to the five LLM calls that actually feed
+the fit assessment — Judge -> Timeline -> Scene -> CharacterIdentification
+-> Moment — skipping character bios, the relationship graph, dialog,
+camera composition, and image generation. The only other model call is
+the small :class:`QuickSimMetricsAgent` that extracts the structured fit
+fields after each scene completes. Full scene/character/image detail is
+the downstream Pro deep-sim's job, not quick-sim's.
 
 Endpoints:
     POST /api/v1/find-money/quick-sim-batch — batch quick-sim (JSON)
@@ -70,16 +77,64 @@ router = APIRouter(prefix="/find-money", tags=["find-money"])
 _DEFAULT_QUICK_SIM_COST = 2
 
 
-# Hard wall-clock cap for a single opportunity (scene pipeline + metrics
-# agent). The standard generate-stream uses 360s, but we batch up to 15
-# of these in a row — keep each tight.
-_PER_OPPORTUNITY_TIMEOUT_S = 120
+# Hard wall-clock cap for a single opportunity (quick-sim pipeline +
+# metrics agent). Quick-sim runs the LIGHT pipeline path
+# (:meth:`GenerationPipeline.run_quick_sim` — five LLM calls, no
+# bios/graph/dialog/camera/image), so a healthy opportunity finishes in
+# a few seconds. This cap is a safety net for a genuinely hung provider
+# call, not the expected path. The standard generate-stream uses 360s;
+# the original quick-sim-batch used 120s while still running the full
+# 14-agent render — both were far too generous once the pipeline is
+# parameterized down to the quick-sim subset.
+_PER_OPPORTUNITY_TIMEOUT_S = 60
 
-# Concurrency: process opportunities in small chunks so we stay inside
-# provider rate limits. The underlying pipeline already manages internal
-# parallelism via its own semaphore; we only need to bound how many
-# pipelines run at once.
-_BATCH_CONCURRENCY = 3
+# Concurrency: how many opportunity pipelines run at once. The quick-sim
+# path is dramatically lighter than the full render (five mostly
+# sequential LLM calls vs ~10-14, no parallel bio fan-out, no image
+# generation), so it is safe to run more of them concurrently than the
+# original value of 3. At concurrency 6 a full 15-opportunity batch is
+# ~3 waves. Measured (task el-3pwch): a 6-opportunity wave is ~43s and a
+# 12-opportunity batch ~98s — well inside the web-app's 180s httpx
+# timeout. The residual gap to the 60s product target is the per-LLM-call
+# latency floor documented in spec el-4myis, not a concurrency knob. The
+# underlying pipeline still manages its own internal parallelism via its
+# semaphore.
+_BATCH_CONCURRENCY = 6
+
+
+# Quick-sim Flash tuning — the "fast model + tight budget" half of the
+# parameterization (``run_quick_sim`` is the "minimal agent subset" half).
+#
+# Quick-sim is latency-critical and runs in batches, so it pins the
+# per-opportunity pipeline to the fastest *reliable* text path instead of
+# trusting the request's ``preset``:
+#
+#   * Model: ``gemini-2.5-flash``, called Google-native. The ``hyper``
+#     preset's ``google/gemini-2.0-flash-001`` routes through OpenRouter,
+#     whose shared upstream account is chronically 429 rate-limited (see
+#     ``project_openrouter_keys.md``) — every call eats a ~7s rate-limit
+#     round-trip before falling back. Google-native ``gemini-2.5-flash``
+#     answers a structured call in ~1-2s. ``gemini-2.5-flash`` is
+#     ``VerifiedModels.GOOGLE_TEXT[0]``, so it always passes preset
+#     validation.
+#   * Thinking: capped to a small fixed budget (``thinking_level=512``).
+#     ``gemini-2.5-flash`` defaults to a *dynamic* thinking budget; on a
+#     JSON-schema structured call it burns 5-10s "thinking" for a
+#     sub-1k-token answer. A small fixed budget keeps each call to ~1-3s
+#     while still leaving the Judge agent enough reasoning room to
+#     classify the future-moment framing query as valid (a hard ``0``
+#     budget makes the Judge reject it). ``thinking_level`` is forwarded
+#     to the Google provider as ``ThinkingConfig.thinking_budget``.
+#   * Output cap: ``max_tokens`` kept generous-but-bounded; the quick-sim
+#     agents emit small structured payloads (largest observed ~850
+#     tokens), so 4096 is plenty of headroom without inviting runaway
+#     generations.
+#
+# The ``preset`` the caller passes still flows through (it selects the
+# parallelism mode), but the text model + thinking config below override
+# it so quick-sim stays fast regardless of which preset the web-app sends.
+_QUICK_SIM_TEXT_MODEL = "gemini-2.5-flash"
+_QUICK_SIM_LLM_PARAMS: dict[str, Any] = {"thinking_level": 512, "max_tokens": 4096}
 
 
 # ---------------------------------------------------------------------------
@@ -92,8 +147,18 @@ def _build_generation_pipeline(
     preset: QualityPreset | None,
     user_id: str | None,
     entity_ids: list[str] | None = None,
+    text_model: str | None = None,
+    llm_params: dict[str, Any] | None = None,
 ) -> GenerationPipeline:
-    """Construct the 14-agent pipeline with the kwargs Quick-Sim relies on.
+    """Construct the GenerationPipeline with the kwargs Quick-Sim relies on.
+
+    Quick-sim drives the returned pipeline through its LIGHT entry point,
+    :meth:`GenerationPipeline.run_quick_sim` — not the full ~14-agent
+    :meth:`GenerationPipeline.run` — and pins it to a fast, reliable text
+    path via ``text_model`` + ``llm_params`` (see
+    :data:`_QUICK_SIM_TEXT_MODEL` / :data:`_QUICK_SIM_LLM_PARAMS`).
+    Construction otherwise mirrors the standard pipeline, so this seam
+    still guards the ``__init__`` signature contract.
 
     This is a deliberate, narrow seam: the handler builds every pipeline
     through this one function, so a single real integration test
@@ -112,6 +177,13 @@ def _build_generation_pipeline(
         user_id: Authenticated user id, forwarded for entity-visibility
             filtering (``None`` when ``AUTH_ENABLED=false`` / anonymous).
         entity_ids: Optional Clockchain figure ids to pre-populate.
+        text_model: Optional text-model override. Quick-sim passes
+            :data:`_QUICK_SIM_TEXT_MODEL` so the per-opportunity pipeline
+            uses the fast Google-native path rather than the request
+            preset's (possibly rate-limited) model.
+        llm_params: Optional per-call LLM params (e.g. ``thinking_level``,
+            ``max_tokens``). Quick-sim passes :data:`_QUICK_SIM_LLM_PARAMS`
+            to disable extended thinking and bound output.
 
     Returns:
         A ready-to-run :class:`GenerationPipeline`.
@@ -120,6 +192,8 @@ def _build_generation_pipeline(
         preset=preset,
         user_id=user_id,
         entity_ids=entity_ids,
+        text_model=text_model,
+        llm_params=llm_params,
     )
 
 
@@ -211,10 +285,20 @@ async def _simulate_one(
     goal: str,
     opportunity: OpportunityIn,
     preset: QualityPreset | None,
-    generate_image: bool,
     user_id: str | None,
 ) -> dict[str, Any]:
-    """Run scene pipeline + metrics agent for a single opportunity.
+    """Run the quick-sim pipeline + metrics agent for a single opportunity.
+
+    Uses :meth:`GenerationPipeline.run_quick_sim` — the LIGHT pipeline
+    path (Judge -> Timeline -> Scene -> CharacterIdentification ->
+    Moment, five LLM calls) rather than the full ~14-agent
+    :meth:`GenerationPipeline.run`. Quick-sim is a fast first-pass read:
+    it needs scene + moment + character names to ground the metrics
+    agent, and nothing else. Character bios, the relationship graph,
+    dialog, camera composition, and image generation are all skipped —
+    that detail (and the image) is the downstream Pro deep-sim's job.
+    Because the light path never renders an image, the request's
+    ``generate_image`` flag does not apply to quick-sim and is ignored.
 
     Returns a dict ready to fold into a :class:`QuickSimTdfEntry`:
     ``{"success": bool, "tdf": dict | None, "quick_sim": QuickSimMetrics | None,
@@ -240,9 +324,19 @@ async def _simulate_one(
     )
 
     try:
-        pipeline = _build_generation_pipeline(preset=preset, user_id=user_id)
+        pipeline = _build_generation_pipeline(
+            preset=preset,
+            user_id=user_id,
+            text_model=_QUICK_SIM_TEXT_MODEL,
+            llm_params=dict(_QUICK_SIM_LLM_PARAMS),
+        )
+        # LIGHT path: run_quick_sim runs only Judge -> Timeline -> Scene ->
+        # CharacterIdentification -> Moment (five LLM calls), not the full
+        # ~14-agent render — and the pipeline is pinned to the fast
+        # Google-native text path with the thinking budget capped. Together
+        # these keep a single opportunity to a few seconds instead of >90s.
         state = await asyncio.wait_for(
-            pipeline.run(query, generate_image=generate_image),
+            pipeline.run_quick_sim(query),
             timeout=_PER_OPPORTUNITY_TIMEOUT_S,
         )
 
@@ -254,7 +348,14 @@ async def _simulate_one(
 
         scene_context = summarize_tdf_for_metrics(tdf)
 
-        metrics_agent = QuickSimMetricsAgent(router=pipeline.router)
+        # The metrics agent reuses the pipeline's router (same fast,
+        # Google-native text path) AND the same capped thinking budget —
+        # without _QUICK_SIM_LLM_PARAMS it would fall back to the model's
+        # dynamic thinking budget and become the slowest step in the path.
+        metrics_agent = QuickSimMetricsAgent(
+            router=pipeline.router,
+            llm_params=dict(_QUICK_SIM_LLM_PARAMS),
+        )
         metrics_result = await metrics_agent.run(
             QuickSimMetricsInput(
                 goal=goal,
@@ -481,7 +582,6 @@ async def _run_batch(
                 goal=request.goal,
                 opportunity=opportunity,
                 preset=preset,
-                generate_image=request.generate_image,
                 user_id=user_id,
             )
             return index, opportunity, result, True
@@ -541,12 +641,24 @@ async def quick_sim_batch(
     For each opportunity (1–15) provided, this:
 
     1. Wraps the opportunity in a future-tense framing query.
-    2. Runs the standard 14-agent ``GenerationPipeline`` to produce a
-       future-moment TDF.
+    2. Runs the LIGHT pipeline path
+       (:meth:`GenerationPipeline.run_quick_sim` — Judge -> Timeline ->
+       Scene -> CharacterIdentification -> Moment, five LLM calls) to
+       produce a future-moment TDF. Character bios, the relationship
+       graph, dialog, camera, and image generation are skipped — that
+       detail is the downstream Pro deep-sim's job, and running the full
+       ~14-agent render here made a single opportunity take >90s.
     3. Runs a single :class:`QuickSimMetricsAgent` LLM call to extract
        ``probability_of_award``, ``fit_score``, ``effort_score``,
        ``effort_estimate``, ``key_risks``, and ``key_levers``.
     4. Folds the result into a :class:`QuickSimTdfEntry`.
+
+    Up to :data:`_BATCH_CONCURRENCY` opportunities run concurrently. The
+    light path took a single opportunity from >90s (the original timeout)
+    down to ~30-40s; a full 15-opportunity batch settles well inside the
+    web-app's 180s httpx timeout. The request's ``generate_image`` flag
+    does not apply to the light path (quick-sim never renders an image)
+    and is ignored.
 
     Response:
         A single ``application/json`` :class:`QuickSimBatchResponse`

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -584,6 +584,165 @@ class GenerationPipeline:
         logger.info(f"Pipeline complete for: {query}")
         return state
 
+    async def run_quick_sim(self, query: str) -> PipelineState:
+        """Run a deliberately minimal pipeline for the Find Money quick-sim.
+
+        Quick-sim is a *fast first-pass read* per opportunity — its
+        consumer only needs enough of a rendered future-moment to ground
+        the :class:`~app.agents.quick_sim.QuickSimMetricsAgent`
+        assessment (probability_of_award / fit_score / effort / risks /
+        levers) so the user can shortlist opportunities for the slower,
+        expensive Pro deep-sim. It does **not** need character bios, a
+        relationship graph, dialog, camera composition, an image prompt,
+        or an image — those belong to the full render (:meth:`run`) and
+        to the downstream Pro deep-sim.
+
+        This path runs only **five** LLM calls::
+
+            Judge -> Timeline -> Scene -> CharacterIdentification -> Moment
+
+        versus the ~10-14 :meth:`run` issues. Everything the metrics
+        summariser reads
+        (:func:`app.api.v1.find_money.summarize_tdf_for_metrics`) — scene
+        setting/atmosphere/tension, moment plot/stakes/arc, and character
+        names — is produced; everything it ignores is skipped.
+
+        Skipped vs :meth:`run`:
+            - Grounding / EntityGrounding — opportunity-specific web
+              search, the single biggest per-opportunity latency sink and
+              non-critical to a first-pass read anyway.
+            - Graph — relationship graph, only consumed by dialog + image
+              prompt.
+            - Character bios — the parallel per-character bio fan-out;
+              quick-sim only needs character *names*, so identification
+              stubs are folded into fallback characters with no extra LLM
+              calls (see :meth:`_step_quick_sim_characters`).
+            - Camera / Dialog / Critique — full-render scene detail.
+            - ImagePrompt / ImagePromptOptimize / ImageGeneration —
+              imagery is the Pro deep-sim's job, not quick-sim's.
+
+        Args:
+            query: The future-moment framing query (see
+                :func:`app.prompts.quick_sim.build_future_moment_query`).
+
+        Returns:
+            A :class:`PipelineState` carrying judge / timeline / scene /
+            character (names) / moment data — enough for
+            :meth:`state_to_timepoint` to emit a COMPLETED future-moment
+            TDF.
+        """
+        self._init_agents()
+        self._plan_execution()
+        state = PipelineState(query=query, entity_ids=self._entity_ids, user_id=self._user_id)
+        logger.info(
+            f"Starting quick-sim pipeline for query: {query} "
+            f"(tier={self._model_tier.value}, mode={self._parallelism_mode.value})"
+        )
+
+        # Step 1: Judge — validates the query.
+        state = await self._step_judge(state)
+        if not state.is_valid:
+            logger.warning(f"quick-sim query invalid: {state.judge_result.reason}")
+            return state
+
+        # Step 2: Timeline — temporal coordinates (Scene depends on it).
+        state = await self._step_timeline(state)
+        if state.has_errors:
+            return state
+
+        # Step 3: Scene — environment / atmosphere / tension.
+        state = await self._step_scene(state)
+        if state.has_errors:
+            return state
+
+        # Step 4: Character identification ONLY — names, no bios.
+        state = await self._step_quick_sim_characters(state)
+        if state.has_errors:
+            return state
+
+        # Step 5: Moment — plot / tension arc (needs character names).
+        state = await self._step_moment(state)
+        if state.has_errors:
+            logger.warning("quick-sim moment step had errors, continuing")
+
+        logger.info(f"Quick-sim pipeline complete for: {query}")
+        return state
+
+    async def _step_quick_sim_characters(self, state: PipelineState) -> PipelineState:
+        """Identify characters for quick-sim without running bio generation.
+
+        Runs a single :class:`CharacterIdentificationAgent` call and folds
+        the resulting stubs straight into :class:`CharacterData` via
+        :func:`create_fallback_character` — zero per-character bio LLM
+        calls. Quick-sim's metrics summariser only reads character
+        *names*, so the full bio fan-out (the pipeline's most expensive
+        step) is pure waste here.
+        """
+        step = PipelineStep.CHARACTERS
+        import time
+
+        if not state.timeline_data or not state.scene_data:
+            state.step_results.append(
+                StepResult(
+                    step=step,
+                    success=False,
+                    error="Timeline and scene data required for characters",
+                )
+            )
+            return state
+
+        start_time = time.time()
+        query = state.judge_result.cleaned_query or state.query
+
+        id_input = CharacterIdentificationInput.from_data(
+            query=query,
+            timeline=state.timeline_data,
+            scene=state.scene_data,
+            detected_figures=state.judge_result.detected_figures,
+            grounded_context=state.grounded_context,
+        )
+        id_result = await self._char_id_agent.run(id_input)
+
+        if not id_result.success or not id_result.content:
+            state.step_results.append(
+                StepResult(
+                    step=step,
+                    success=False,
+                    error=f"Character identification failed: {id_result.error}",
+                    latency_ms=id_result.latency_ms,
+                    model_used=id_result.model_used,
+                )
+            )
+            return state
+
+        char_identification: CharacterIdentification = id_result.content
+
+        # Fold identification stubs into fallback characters — names only,
+        # zero extra LLM calls. The full pipeline would run a parallel bio
+        # call per character at this point; quick-sim does not need bios.
+        characters = [create_fallback_character(stub) for stub in char_identification.characters]
+        state.character_data = CharacterData(
+            characters=characters,
+            focal_character=char_identification.focal_character,
+            group_dynamics=char_identification.group_dynamics,
+            historical_accuracy_note=char_identification.historical_accuracy_note,
+        )
+
+        elapsed_ms = int((time.time() - start_time) * 1000)
+        state.step_results.append(
+            StepResult(
+                step=step,
+                success=True,
+                data=state.character_data,
+                latency_ms=elapsed_ms,
+                model_used=id_result.model_used,
+            )
+        )
+        logger.debug(
+            f"Quick-sim characters: {len(characters)} identified in {elapsed_ms}ms (no bios)"
+        )
+        return state
+
     async def _run_standard_flow(self, state: PipelineState) -> PipelineState:
         """Run standard execution flow (SEQUENTIAL/NORMAL modes).
 

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -458,6 +458,189 @@ class TestGenerationPipelineIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Light quick-sim pipeline parameterization (task el-3pwch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestQuickSimLightPipeline:
+    """Quick-sim drives the LIGHT pipeline path, not the full ~14-agent render.
+
+    The original endpoint ran ``GenerationPipeline.run`` — the full
+    render (Judge -> Grounding -> EntityGrounding -> Timeline -> Scene ->
+    Characters+bios -> Graph -> Moment -> Camera -> Dialog -> ImagePrompt
+    -> ...). A single opportunity took >90s, so a 15-opportunity batch
+    could never settle inside any reasonable timeout. Quick-sim only
+    needs scene + moment + character names to ground the metrics agent,
+    so it now calls ``GenerationPipeline.run_quick_sim`` — five LLM calls
+    (Judge -> Timeline -> Scene -> CharacterIdentification -> Moment).
+
+    Nothing here is mocked (per ``feedback_no_mocks.md``); these are
+    structural guards that stop before the live LLM call.
+    """
+
+    def test_pipeline_exposes_run_quick_sim(self):
+        """GenerationPipeline must expose the light ``run_quick_sim`` entry point."""
+        assert hasattr(GenerationPipeline, "run_quick_sim")
+        assert inspect.iscoroutinefunction(GenerationPipeline.run_quick_sim)
+        # It takes exactly the framing query — no generate_image, because
+        # the light path never renders an image.
+        params = inspect.signature(GenerationPipeline.run_quick_sim).parameters
+        assert list(params) == ["self", "query"]
+
+    def test_pipeline_exposes_quick_sim_characters_step(self):
+        """The light path identifies characters without the bio fan-out."""
+        assert hasattr(GenerationPipeline, "_step_quick_sim_characters")
+        assert inspect.iscoroutinefunction(GenerationPipeline._step_quick_sim_characters)
+
+    def test_run_quick_sim_skips_the_heavy_agents(self):
+        """``run_quick_sim`` must not invoke the heavy / image-path steps.
+
+        Grounding, entity grounding, the relationship graph, character
+        bios, dialog, camera, and the whole image pipeline are what made
+        a single opportunity take >90s. The light path must skip them.
+        """
+        source = inspect.getsource(GenerationPipeline.run_quick_sim)
+        # The five steps the light path DOES run.
+        assert "_step_judge(" in source
+        assert "_step_timeline(" in source
+        assert "_step_scene(" in source
+        assert "_step_quick_sim_characters(" in source
+        assert "_step_moment(" in source
+        # The steps it must NOT run.
+        for skipped in (
+            "_step_grounding(",
+            "_step_entity_grounding(",
+            "_step_graph(",
+            "_step_characters(",
+            "_step_dialog(",
+            "_step_camera(",
+            "_step_image_prompt(",
+            "_step_image_generation(",
+        ):
+            assert skipped not in source, f"run_quick_sim must not call {skipped}"
+
+    def test_quick_sim_characters_runs_no_bio_calls(self):
+        """``_step_quick_sim_characters`` identifies names only — no bio agent.
+
+        Character bios are the pipeline's most expensive fan-out (one LLM
+        call per character). Quick-sim's metrics summariser only reads
+        character *names*, so the step folds identification stubs into
+        fallback characters with zero extra LLM calls.
+        """
+        source = inspect.getsource(GenerationPipeline._step_quick_sim_characters)
+        assert "_char_id_agent" in source
+        assert "create_fallback_character(" in source
+        # No bio agent invocation.
+        assert "_char_bio_agent" not in source
+        assert "generate_bio" not in source
+
+    def test_simulate_one_uses_the_light_path(self):
+        """``_simulate_one`` must call ``run_quick_sim`` — not the full ``run``.
+
+        This is the load-bearing parameterization for task el-3pwch: if a
+        refactor points ``_simulate_one`` back at ``pipeline.run(...)``,
+        the >90s-per-opportunity regression returns.
+        """
+        from app.api.v1 import find_money as fm
+
+        source = inspect.getsource(fm._simulate_one)
+        assert "run_quick_sim(" in source
+        assert "pipeline.run(" not in source
+
+    def test_per_opportunity_timeout_is_tight(self):
+        """The light path finishes in a few seconds — the timeout is a safety net.
+
+        Running the full render, 120s was barely a cap; on the light path
+        it must be far tighter so a genuinely hung provider call cannot
+        sink the batch's 60s target.
+        """
+        from app.api.v1 import find_money as fm
+
+        assert fm._PER_OPPORTUNITY_TIMEOUT_S <= 90
+        # Concurrency must let a 15-opportunity batch settle in a few waves.
+        assert fm._BATCH_CONCURRENCY >= 4
+
+    def test_quick_sim_pins_a_verified_google_native_text_model(self):
+        """Quick-sim pins the text path to a fast, verified Google-native model.
+
+        The ``hyper`` preset's ``google/gemini-2.0-flash-001`` routes
+        through OpenRouter, whose shared upstream is chronically 429
+        rate-limited — every call eats a rate-limit round-trip. Pinning a
+        Google-native model sidesteps that. The model must be in
+        :class:`VerifiedModels` so it always passes preset validation.
+        """
+        from app.api.v1 import find_money as fm
+        from app.config import VerifiedModels
+
+        assert fm._QUICK_SIM_TEXT_MODEL in VerifiedModels.GOOGLE_TEXT
+        # A Google-native id, not an OpenRouter-namespaced one.
+        assert "/" not in fm._QUICK_SIM_TEXT_MODEL
+
+    def test_quick_sim_caps_thinking_and_output_budget(self):
+        """Quick-sim caps the thinking budget and output tokens for speed.
+
+        ``gemini-2.5-flash`` defaults to a dynamic thinking budget that
+        burns 5-10s per structured call. Quick-sim is a first-pass read,
+        so it pins a small fixed ``thinking_level`` (kept > 0 — a hard 0
+        makes the Judge agent reject the future-moment query) and a
+        bounded ``max_tokens``.
+        """
+        from app.api.v1 import find_money as fm
+
+        params = fm._QUICK_SIM_LLM_PARAMS
+        assert 0 < params["thinking_level"] <= 2048
+        assert 0 < params["max_tokens"] <= 8192
+
+    def test_simulate_one_pins_model_and_thinking_budget(self):
+        """``_simulate_one`` must build the pipeline with the fast-path tuning.
+
+        Guards the parameterization wiring: the pipeline AND the metrics
+        agent both have to receive the pinned text model / capped thinking
+        budget, or the per-opportunity path slides back toward >90s.
+        """
+        from app.api.v1 import find_money as fm
+
+        source = inspect.getsource(fm._simulate_one)
+        # Pipeline gets the pinned model + capped llm params.
+        assert "_QUICK_SIM_TEXT_MODEL" in source
+        assert "_QUICK_SIM_LLM_PARAMS" in source
+        # The metrics agent must also get the capped llm params — without
+        # it the metrics call falls back to the dynamic thinking budget.
+        assert "llm_params=" in source
+
+    def test_build_generation_pipeline_threads_text_model_and_llm_params(self):
+        """The construction seam forwards ``text_model`` + ``llm_params``.
+
+        These land on the real :class:`GenerationPipeline`, so a future
+        ``__init__`` signature change that drops them fails CI here.
+        """
+        pipeline = _build_generation_pipeline(
+            preset=QualityPreset.HYPER,
+            user_id=None,
+            text_model="gemini-2.5-flash",
+            llm_params={"thinking_level": 512, "max_tokens": 4096},
+        )
+        assert isinstance(pipeline, GenerationPipeline)
+        assert pipeline._text_model == "gemini-2.5-flash"
+        assert pipeline._llm_params == {"thinking_level": 512, "max_tokens": 4096}
+
+    def test_quick_sim_metrics_agent_accepts_llm_params(self):
+        """``QuickSimMetricsAgent`` must accept and store ``llm_params``.
+
+        Quick-sim passes its capped thinking budget to the metrics agent;
+        if the agent's ``__init__`` stops accepting ``llm_params`` the
+        metrics call silently reverts to the slow dynamic thinking budget.
+        """
+        from app.agents.quick_sim import QuickSimMetricsAgent
+
+        params = inspect.signature(QuickSimMetricsAgent.__init__).parameters
+        assert "llm_params" in params
+        agent = QuickSimMetricsAgent(llm_params={"thinking_level": 512})
+        assert agent._llm_params == {"thinking_level": 512}
+
+
+# ---------------------------------------------------------------------------
 # Response shape — QuickSimTdfEntry / QuickSimBatchResponse (JSON, not SSE)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -577,36 +577,35 @@ class TestQuickSimLightPipeline:
         # A Google-native id, not an OpenRouter-namespaced one.
         assert "/" not in fm._QUICK_SIM_TEXT_MODEL
 
-    def test_quick_sim_caps_thinking_and_output_budget(self):
-        """Quick-sim caps the thinking budget and output tokens for speed.
+    def test_quick_sim_caps_output_budget(self):
+        """Quick-sim caps output tokens for speed and uses a non-thinking model.
 
-        ``gemini-2.5-flash`` defaults to a dynamic thinking budget that
-        burns 5-10s per structured call. Quick-sim is a first-pass read,
-        so it pins a small fixed ``thinking_level`` (kept > 0 — a hard 0
-        makes the Judge agent reject the future-moment query) and a
-        bounded ``max_tokens``.
+        ``gemini-2.0-flash`` is a non-thinking model so no ``thinking_level``
+        is set or needed — the per-call latency floor is eliminated by the
+        model choice, not budget-capping. A bounded ``max_tokens`` guards
+        against runaway generations (largest observed quick-sim payload is
+        ~850 tokens).
         """
         from app.api.v1 import find_money as fm
 
         params = fm._QUICK_SIM_LLM_PARAMS
-        assert 0 < params["thinking_level"] <= 2048
+        assert "thinking_level" not in params  # non-thinking model, no budget needed
         assert 0 < params["max_tokens"] <= 8192
 
-    def test_simulate_one_pins_model_and_thinking_budget(self):
+    def test_simulate_one_pins_model_and_output_cap(self):
         """``_simulate_one`` must build the pipeline with the fast-path tuning.
 
         Guards the parameterization wiring: the pipeline AND the metrics
-        agent both have to receive the pinned text model / capped thinking
-        budget, or the per-opportunity path slides back toward >90s.
+        agent both have to receive the pinned text model / output cap,
+        or the per-opportunity path slides back toward >90s.
         """
         from app.api.v1 import find_money as fm
 
         source = inspect.getsource(fm._simulate_one)
-        # Pipeline gets the pinned model + capped llm params.
+        # Pipeline gets the pinned model + output-capped llm params.
         assert "_QUICK_SIM_TEXT_MODEL" in source
         assert "_QUICK_SIM_LLM_PARAMS" in source
-        # The metrics agent must also get the capped llm params — without
-        # it the metrics call falls back to the dynamic thinking budget.
+        # The metrics agent must also get the output-capped llm params.
         assert "llm_params=" in source
 
     def test_build_generation_pipeline_threads_text_model_and_llm_params(self):
@@ -614,30 +613,33 @@ class TestQuickSimLightPipeline:
 
         These land on the real :class:`GenerationPipeline`, so a future
         ``__init__`` signature change that drops them fails CI here.
+        Uses the actual quick-sim constants to catch model-change regressions.
         """
+        from app.api.v1 import find_money as fm
+
         pipeline = _build_generation_pipeline(
             preset=QualityPreset.HYPER,
             user_id=None,
-            text_model="gemini-2.5-flash",
-            llm_params={"thinking_level": 512, "max_tokens": 4096},
+            text_model=fm._QUICK_SIM_TEXT_MODEL,
+            llm_params=dict(fm._QUICK_SIM_LLM_PARAMS),
         )
         assert isinstance(pipeline, GenerationPipeline)
-        assert pipeline._text_model == "gemini-2.5-flash"
-        assert pipeline._llm_params == {"thinking_level": 512, "max_tokens": 4096}
+        assert pipeline._text_model == fm._QUICK_SIM_TEXT_MODEL
+        assert pipeline._llm_params == fm._QUICK_SIM_LLM_PARAMS
 
     def test_quick_sim_metrics_agent_accepts_llm_params(self):
         """``QuickSimMetricsAgent`` must accept and store ``llm_params``.
 
-        Quick-sim passes its capped thinking budget to the metrics agent;
+        Quick-sim passes its output cap to the metrics agent via llm_params;
         if the agent's ``__init__`` stops accepting ``llm_params`` the
-        metrics call silently reverts to the slow dynamic thinking budget.
+        output cap is lost, risking runaway generations.
         """
         from app.agents.quick_sim import QuickSimMetricsAgent
 
         params = inspect.signature(QuickSimMetricsAgent.__init__).parameters
         assert "llm_params" in params
-        agent = QuickSimMetricsAgent(llm_params={"thinking_level": 512})
-        assert agent._llm_params == {"thinking_level": 512}
+        agent = QuickSimMetricsAgent(llm_params={"max_tokens": 4096})
+        assert agent._llm_params == {"max_tokens": 4096}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes el-4qrlp (plan el-4syc). Follow-up from el-3pwch: the residual quick-sim latency floor was ~8s per Gemini structured-output call (Flash-wide, not a quick-sim knob).