### PR TITLE
fix(credits): deduct on /timepoints/generate/stream + refund on failure (el-1obje)

### DIFF
--- a/app/api/v1/timepoints.py
+++ b/app/api/v1/timepoints.py
@@ -623,6 +623,8 @@ async def stream_generation(
     disconnect_check=None,
     entity_ids: list[str] | None = None,
     user_id: str | None = None,
+    refund_cost: int = 0,
+    preset_label: str = "balanced",
 ) -> AsyncGenerator[str, None]:
     """Generate SSE events for pipeline progress with real-time streaming.
 
@@ -639,6 +641,12 @@ async def stream_generation(
         disconnect_check: Optional async callable that returns True if client disconnected
         entity_ids: Optional Clockchain figure IDs for entity library reuse
         user_id: Optional user ID for entity visibility filtering
+        refund_cost: Credits to refund if the stream fails before emitting
+            ``done`` (timeout, pipeline exception, DB save failure, or no
+            state produced). Pass ``0`` to disable refunds (e.g. when the
+            Gateway is metering the request and Flash did not deduct).
+        preset_label: Human-readable preset name used in the refund
+            transaction description.
 
     Yields:
         SSE-formatted event strings
@@ -675,6 +683,32 @@ async def stream_generation(
     )
     state = None
     start_time = time.perf_counter()
+    done_emitted = False
+
+    async def _refund_on_failure(reason: str) -> None:
+        """Refund credits to the user when the stream fails before ``done``.
+
+        Mirrors the refund pattern in /generate (background) and
+        /generate/sync. Opens its own session because the endpoint's
+        dependency-managed session has already been closed by the time
+        this generator runs.
+        """
+        if refund_cost <= 0 or not user_id:
+            return
+        try:
+            from app.database import get_session
+
+            async with get_session() as refund_session:
+                await grant_credits(
+                    refund_session,
+                    user_id,
+                    refund_cost,
+                    TransactionType.REFUND,
+                    description=f"Refund (stream {reason}): {query[:60]}",
+                )
+            logger.info(f"Refunded {refund_cost} credits to user {user_id} after stream {reason}")
+        except Exception as refund_err:  # pragma: no cover — defensive
+            logger.error(f"Credit refund failed after stream {reason}: {refund_err}")
 
     # Debug log to verify generate_image value
     logger.info(
@@ -775,6 +809,7 @@ async def stream_generation(
                                 progress=100,
                             )
                         )
+                        done_emitted = True
                 except Exception as db_error:
                     logger.error(f"Failed to save streaming result: {db_error}")
                     # Send error event when database save fails
@@ -812,6 +847,14 @@ async def stream_generation(
                 progress=0,
             )
         )
+
+    finally:
+        # Refund credits if the stream did not reach a successful ``done``
+        # event (timeout, pipeline exception, DB save failure, or no state
+        # was produced). The endpoint deducted credits up-front; this is
+        # the inverse on the failure path. Mirrors /generate/sync.
+        if not done_emitted:
+            await _refund_on_failure("aborted")
 
 
 # Background Task for Generation
@@ -1531,6 +1574,7 @@ async def generate_timepoint_stream(
     raw_request: Request,
     user: User | None = Depends(get_current_user),
     _credits=Depends(require_credits(CREDIT_COSTS["generate_balanced"])),
+    session: AsyncSession = Depends(get_db_session),
 ) -> StreamingResponse:
     """Generate timepoint with SSE streaming progress.
 
@@ -1576,6 +1620,33 @@ async def generate_timepoint_stream(
     else:
         logger.info(f"Stream generate request: {request.query}")
 
+    # Deduct credits up-front (mirrors /generate and /generate/sync). The
+    # ``require_credits`` dependency above only verifies the balance is
+    # sufficient — it does NOT deduct. Without an explicit ``spend_credits``
+    # call the stream endpoint generates a full timepoint for free, which is
+    # the root cause of "credits do not deduct on timepoint generation"
+    # (task el-1obje). The dependency-managed ``session`` is committed by
+    # ``get_db_session`` when this function returns, BEFORE Starlette begins
+    # iterating the StreamingResponse body. Refunds inside the stream open
+    # their own session via ``get_session()``.
+    #
+    # When the Gateway has already metered the request
+    # (``X-Gateway-Metered: true``) we skip the deduction here to avoid
+    # double-charging — same pattern as ``find_money`` quick-sim-batch.
+    preset_label = request.preset or "balanced"
+    cost = 0
+    gateway_metered = raw_request.headers.get("X-Gateway-Metered", "").lower() == "true"
+    if user is not None and not gateway_metered:
+        preset_key = f"generate_{preset_label}"
+        cost = CREDIT_COSTS.get(preset_key, CREDIT_COSTS["generate_balanced"])
+        await spend_credits(
+            session,
+            user.id,
+            cost,
+            TransactionType.GENERATION,
+            description=f"Generate stream ({preset_label}): {request.query[:60]}",
+        )
+
     # Resolve model_policy → concrete models
     text_model, image_model = resolve_model_policy(request)
 
@@ -1593,6 +1664,8 @@ async def generate_timepoint_stream(
             disconnect_check=raw_request.is_disconnected,
             entity_ids=request.entity_ids,
             user_id=user.id if user is not None else None,
+            refund_cost=cost,
+            preset_label=preset_label,
         ),
         media_type="text/event-stream",
         headers={

--- a/tests/integration/test_stream_credit_deduction.py
+++ b/tests/integration/test_stream_credit_deduction.py
@@ -1,0 +1,159 @@
+"""Regression tests for credit deduction on /api/v1/timepoints/generate/stream.
+
+Covers task el-1obje: before the fix, the SSE streaming endpoint only ran the
+``require_credits`` pre-flight balance check and never called
+``spend_credits``, so authenticated callers generated timepoints for free.
+
+These tests pin the behavior:
+    1. ``stream_generation`` refunds credits via ``grant_credits`` when the
+       pipeline fails before emitting the terminal ``done`` event.
+    2. ``stream_generation`` does NOT refund when ``refund_cost == 0``
+       (e.g. ``X-Gateway-Metered: true`` requests where Flash never deducted).
+    3. ``generate_timepoint_stream`` is wired with the
+       ``X-Gateway-Metered`` short-circuit and the up-front ``spend_credits``
+       call (verified via source inspection — the full HTTP flow needs an
+       AUTH_ENABLED test client which the existing harness does not provide).
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.api.v1 import timepoints as timepoints_module
+from app.api.v1.timepoints import generate_timepoint_stream, stream_generation
+from app.auth.credits import spend_credits
+from app.models_auth import CreditAccount, TransactionType, User
+
+
+@pytest.mark.asyncio
+@pytest.mark.fast
+async def test_stream_refunds_on_pipeline_exception(db_session):
+    """When the pipeline raises, ``stream_generation`` refunds the cost.
+
+    Mirrors the refund path in ``/generate/sync``: charge up-front, refund
+    if generation fails before the terminal ``done`` event.
+    """
+    user = User(apple_sub="stream-refund-001")
+    db_session.add(user)
+    await db_session.flush()
+
+    account = CreditAccount(user_id=user.id, balance=10, lifetime_earned=10, lifetime_spent=0)
+    db_session.add(account)
+    await db_session.flush()
+
+    # Simulate the endpoint's up-front deduction.
+    await spend_credits(db_session, user.id, 5, TransactionType.GENERATION, description="up-front")
+    await db_session.commit()
+    assert account.balance == 5
+
+    # Force the pipeline to raise so the failure path runs.
+    class _BoomPipeline:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def run_streaming(self, *args, **kwargs):  # pragma: no cover
+            raise RuntimeError("boom")
+            yield  # make this an async generator
+
+        def state_to_timepoint(self, state):  # pragma: no cover
+            raise NotImplementedError
+
+        def state_to_generation_logs(self, state):  # pragma: no cover
+            raise NotImplementedError
+
+    with patch.object(timepoints_module, "GenerationPipeline", _BoomPipeline):
+        gen = stream_generation(
+            query="declaration of independence",
+            generate_image=False,
+            user_id=user.id,
+            refund_cost=5,
+            preset_label="balanced",
+        )
+        events = [event async for event in gen]
+
+    # Stream should have emitted an error event but no ``done`` event.
+    assert any("error" in event for event in events), events
+    assert not any('"event":"done"' in event for event in events), events
+
+    # Refund issued — balance restored to original.
+    await db_session.refresh(account)
+    assert account.balance == 10, f"expected refund to restore balance to 10, got {account.balance}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.fast
+async def test_stream_does_not_refund_when_cost_zero(db_session):
+    """If ``refund_cost == 0`` no refund is attempted.
+
+    This covers the gateway-metered path (Flash never deducted, so it must
+    not refund either).
+    """
+    user = User(apple_sub="stream-refund-002")
+    db_session.add(user)
+    await db_session.flush()
+
+    account = CreditAccount(user_id=user.id, balance=10, lifetime_earned=10, lifetime_spent=0)
+    db_session.add(account)
+    await db_session.flush()
+    await db_session.commit()
+
+    grant_spy = AsyncMock()
+    with patch.object(timepoints_module, "grant_credits", grant_spy):
+
+        class _BoomPipeline:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def run_streaming(self, *args, **kwargs):  # pragma: no cover
+                raise RuntimeError("boom")
+                yield
+
+            def state_to_timepoint(self, state):  # pragma: no cover
+                raise NotImplementedError
+
+            def state_to_generation_logs(self, state):  # pragma: no cover
+                raise NotImplementedError
+
+        with patch.object(timepoints_module, "GenerationPipeline", _BoomPipeline):
+            gen = stream_generation(
+                query="declaration of independence",
+                generate_image=False,
+                user_id=user.id,
+                refund_cost=0,
+                preset_label="balanced",
+            )
+            _ = [event async for event in gen]
+
+    grant_spy.assert_not_awaited()
+
+
+@pytest.mark.fast
+def test_stream_endpoint_signature_accepts_session():
+    """Regression guard: the endpoint must take a session dependency so it
+    can call ``spend_credits`` at request time."""
+    sig = inspect.signature(generate_timepoint_stream)
+    assert "session" in sig.parameters, (
+        "generate_timepoint_stream must accept a session dependency to deduct credits"
+    )
+
+
+@pytest.mark.fast
+def test_stream_endpoint_calls_spend_credits():
+    """Regression guard: the endpoint source must call ``spend_credits``.
+
+    Before el-1obje the endpoint only used ``require_credits`` (balance
+    check) and never deducted. We pin the source-level invariant so the
+    deduction can't silently regress.
+    """
+    source = inspect.getsource(generate_timepoint_stream)
+    assert "spend_credits(" in source, (
+        "generate_timepoint_stream must call spend_credits — credit deduction "
+        "regressed to pre-el-1obje behavior"
+    )
+    assert "X-Gateway-Metered" in source, (
+        "generate_timepoint_stream must honor X-Gateway-Metered to avoid "
+        "double-charging when the Gateway already metered the request"
+    )


### PR DESCRIPTION
Closes el-1obje (plan el-3wuc). Owner: 'when I run timepoint credits do not deduct.'

ROOT CAUSE: /api/v1/timepoints/generate/stream in app/api/v1/timepoints.py only ran require_credits (balance check) — it NEVER called spend_credits. /generate and /generate/sync both deduct correctly (lines 1050 + 1134); only the streaming endpoint was missing the deduction. Web-app SSE-proxies into this endpoint (app/flash_client.py:376-407) and trusts Flash to own deduction, so every streamed timepoint was free. Gateway is NOT compensating — METERING_ENABLED defaults to False in gateway/config.py:89.

FIX:
- Add session dependency + spend_credits call up-front on /generate/stream
- Honor X-Gateway-Metered: true to skip dedup if gateway flips on metering later
- Pass refund_cost/preset_label into stream_generation; refund via grant_credits in a finally block on TimeoutError / pipeline exception / DB save failure / no state produced

Failed generations: were charged-and-not-refunded for streaming, refunded for sync. Now consistent — refunded for both.

Tests: 4 new in tests/integration/test_stream_credit_deduction.py (pass); 100 integration tests total pass; ruff clean.