### PR TITLE
fix(generate): surface real error instead of 'Unknown error' (el-38cej)

### DIFF
--- a/app/api/v1/timepoints.py
+++ b/app/api/v1/timepoints.py
@@ -915,14 +915,27 @@ async def run_generation_task(
                     await _fire_callback(callback_url, resp.model_dump(mode="json"))
 
     except Exception as e:
-        logger.error(f"Background generation failed for {timepoint_id}: {e}")
+        # Log with traceback so the real cause is captured in Sentry/Logfire/
+        # Railway logs even when str(e) collapses to something opaque.
+        logger.exception(
+            "Background generation failed for %s: %s: %s",
+            timepoint_id,
+            type(e).__name__,
+            e,
+        )
         # Update status to failed and refund credits
         async with get_session() as session:
             result = await session.execute(select(Timepoint).where(Timepoint.id == timepoint_id))
             tp = result.scalar_one_or_none()
             if tp:
                 tp.status = TimepointStatus.FAILED
-                tp.error_message = str(e)
+                # Prefix with the exception type so bare-string failures like
+                # asyncio.TimeoutError (which stringifies to "") still surface
+                # a useful identifier instead of an empty error_message.
+                err_text = str(e).strip()
+                tp.error_message = (
+                    f"{type(e).__name__}: {err_text}" if err_text else type(e).__name__
+                )
 
                 # Refund credits if this was a user-initiated generation
                 if tp.user_id:
@@ -948,12 +961,14 @@ async def run_generation_task(
 
         # Fire callback with error if requested
         if callback_url:
+            err_text = str(e).strip()
+            callback_error = f"{type(e).__name__}: {err_text}" if err_text else type(e).__name__
             await _fire_callback(
                 callback_url,
                 {
                     "id": timepoint_id,
                     "status": "failed",
-                    "error": str(e),
+                    "error": callback_error,
                     "request_context": request_context,
                 },
             )

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -1245,12 +1245,34 @@ class GenerationPipeline:
             # Create a failed judge result
             state.judge_result = JudgeAgent.create_failed_result(result.error)
 
+        # If the judge ran successfully but rejected the query as invalid, we
+        # still want the rejection reason to surface as a step-level error so
+        # the failed timepoint's error_message is informative instead of an
+        # opaque "Unknown error". (Previously: result.success=True + judge says
+        # is_valid=False produced StepResult.error=None, which then fell
+        # through state_to_timepoint's "Unknown error" fallback.)
+        step_error = result.error
+        if (
+            step_error is None
+            and state.judge_result is not None
+            and not state.judge_result.is_valid
+        ):
+            reason = (state.judge_result.reason or "").strip()
+            step_error = (
+                f"Query rejected by judge: {reason}"
+                if reason
+                else "Query rejected by judge (no reason provided)"
+            )
+
         state.step_results.append(
             StepResult(
                 step=step,
-                success=result.success,
+                # When the judge rejects the query, treat the step as failed so
+                # downstream error reporting captures it as a real failure
+                # rather than a silent invalidation.
+                success=result.success and state.judge_result.is_valid,
                 data=state.judge_result,
-                error=result.error,
+                error=step_error,
                 latency_ms=result.latency_ms,
                 model_used=result.model_used,
             )
@@ -2377,10 +2399,60 @@ class GenerationPipeline:
 
         # Add error if failed
         if status == TimepointStatus.FAILED:
-            errors = [r.error for r in state.step_results if r.error]
-            timepoint.error_message = "; ".join(errors) if errors else "Unknown error"
+            timepoint.error_message = self._build_failure_error_message(state)
 
         return timepoint
+
+    @staticmethod
+    def _build_failure_error_message(state: PipelineState) -> str:
+        """Build a human-readable error_message for a failed pipeline run.
+
+        Replaces the legacy "Unknown error" fallback with the most informative
+        string we can reconstruct from the pipeline state:
+
+        1. Concatenate every failed step's name + error (e.g. "judge: ...; dialog: ...").
+        2. If no step recorded an error but the judge marked the query invalid,
+           surface the judge's rejection reason — that case used to produce
+           "Unknown error" because the step succeeded at the agent level even
+           though the judge said is_valid=False.
+        3. As a last resort, name the steps that ran and the steps that were
+           skipped, so debugging doesn't start from a blank string. Also log a
+           warning so we can find these cases in the logs going forward.
+        """
+        # Collect per-step failure details with step names attached so the
+        # web app / iOS app / Sentry can show "dialog: 502 Bad Gateway"
+        # instead of just "502 Bad Gateway".
+        step_failures: list[str] = []
+        for r in state.step_results:
+            if r.success or not r.error:
+                continue
+            step_failures.append(f"{r.step.value}: {r.error}")
+
+        if step_failures:
+            return "; ".join(step_failures)
+
+        # Step results had no error string. The most common path here is the
+        # judge marking the query invalid via a successful LLM call.
+        if state.judge_result is not None and not state.judge_result.is_valid:
+            reason = (state.judge_result.reason or "").strip()
+            if reason:
+                return f"Query rejected by judge: {reason}"
+            return "Query rejected by judge (no reason provided)"
+
+        # Final fallback: name what ran so the failure isn't a black box.
+        ran = [r.step.value for r in state.step_results]
+        logger.warning(
+            "Pipeline marked FAILED but no step recorded an error. "
+            "is_valid=%s, judge_result=%r, step_results=%s",
+            state.is_valid,
+            state.judge_result,
+            ran,
+        )
+        if ran:
+            return (
+                f"Generation failed with no specific step error. Steps executed: {', '.join(ran)}."
+            )
+        return "Generation failed before any pipeline step ran."
 
     def state_to_generation_logs(self, state: PipelineState) -> list[GenerationLog]:
         """Convert step results to generation logs.

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -239,7 +239,12 @@ class TestGenerationPipeline:
         assert timepoint.status.value == "completed"
 
     def test_state_to_timepoint_failed(self):
-        """Test converting failed state to timepoint."""
+        """Test converting failed state to timepoint.
+
+        Regression: when the judge runs successfully but rejects the query as
+        invalid, the timepoint's error_message must surface the judge's
+        rejection reason instead of the legacy "Unknown error" string.
+        """
         state = PipelineState(query="invalid query")
         state.judge_result = JudgeResult(
             is_valid=False,
@@ -254,6 +259,76 @@ class TestGenerationPipeline:
         timepoint = pipeline.state_to_timepoint(state)
 
         assert timepoint.status.value == "failed"
+        assert timepoint.error_message is not None
+        assert "Unknown error" not in timepoint.error_message
+        assert "Query too vague" in timepoint.error_message
+
+    def test_state_to_timepoint_failed_collects_step_errors(self):
+        """Failed timepoint error_message should include every failed step's error.
+
+        Previously errors were joined with no step name, so consumers could not
+        tell which step blew up. Now each entry is prefixed with the step name.
+        """
+        state = PipelineState(query="some query")
+        state.judge_result = JudgeResult(
+            is_valid=True,
+            query_type=QueryType.HISTORICAL,
+            cleaned_query="some query",
+        )
+        state.step_results = [
+            StepResult(step=PipelineStep.JUDGE, success=True),
+            StepResult(
+                step=PipelineStep.TIMELINE,
+                success=False,
+                error="upstream provider 502",
+            ),
+            StepResult(
+                step=PipelineStep.SCENE,
+                success=False,
+                error="Timeline data required for scene generation",
+            ),
+        ]
+
+        pipeline = GenerationPipeline()
+        timepoint = pipeline.state_to_timepoint(state)
+
+        assert timepoint.status.value == "failed"
+        assert timepoint.error_message is not None
+        assert "timeline: upstream provider 502" in timepoint.error_message
+        assert "scene: Timeline data required for scene generation" in timepoint.error_message
+        assert "Unknown error" not in timepoint.error_message
+
+    def test_state_to_timepoint_failed_fallback_names_steps(self):
+        """Last-resort fallback should still name what ran instead of "Unknown error".
+
+        This covers the edge case where a critical step is marked as failed but
+        somehow has no error string attached — the old code would emit literal
+        "Unknown error"; the new code names the steps that executed.
+        """
+        state = PipelineState(query="some query")
+        state.judge_result = JudgeResult(
+            is_valid=True,
+            query_type=QueryType.HISTORICAL,
+            cleaned_query="some query",
+        )
+        state.step_results = [
+            StepResult(step=PipelineStep.JUDGE, success=True),
+            # Critical step failed without populating an error string. This
+            # exists today in production e.g. when a step body raises and the
+            # caller forgets to forward .error — surface what we know instead
+            # of producing "Unknown error".
+            StepResult(step=PipelineStep.TIMELINE, success=False, error=None),
+        ]
+
+        pipeline = GenerationPipeline()
+        timepoint = pipeline.state_to_timepoint(state)
+
+        assert timepoint.status.value == "failed"
+        assert timepoint.error_message is not None
+        assert "Unknown error" not in timepoint.error_message
+        # The fallback should at minimum identify which steps executed.
+        assert "judge" in timepoint.error_message
+        assert "timeline" in timepoint.error_message
 
     def test_state_to_generation_logs(self):
         """Test converting state to generation logs."""
@@ -384,6 +459,78 @@ class TestGenerationPipeline:
         assert timepoint.tdf.get("moment_data") is not None
         assert timepoint.tdf["moment_data"]["tension_arc"] == "climactic"
         assert timepoint.tdf["moment_data"]["stakes"] == "American independence"
+
+
+@pytest.mark.fast
+class TestStepJudgeRejection:
+    """Tests for _step_judge rejection-path error surfacing.
+
+    Regression coverage for "Unknown error" appearing on the timepoint when the
+    judge LLM ran successfully but rejected the query as invalid.
+    """
+
+    async def test_step_judge_rejection_populates_step_error(self):
+        """Successful judge call that flags is_valid=False must record a step error.
+
+        Otherwise state_to_timepoint can only emit "Unknown error" — the
+        original bug that hid real rejection reasons from users.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.agents.base import AgentResult
+
+        pipeline = GenerationPipeline()
+        # Avoid real router/agent initialization
+        pipeline._judge_agent = MagicMock()
+        rejected = JudgeResult(
+            is_valid=False,
+            query_type=QueryType.INVALID,
+            reason="Query is too personal to render as a scene",
+        )
+        pipeline._judge_agent.run = AsyncMock(
+            return_value=AgentResult(
+                success=True,
+                content=rejected,
+                latency_ms=42,
+                model_used="gemini-3-pro",
+            )
+        )
+
+        state = PipelineState(query="my wife's 43rd birthday")
+        state = await pipeline._step_judge(state)
+
+        assert state.is_valid is False
+        judge_step = state.get_step_result(PipelineStep.JUDGE)
+        assert judge_step is not None
+        # Judge rejection should now be modeled as a step failure so downstream
+        # error reporting sees it as a real failure, not a silent invalidation.
+        assert judge_step.success is False
+        assert judge_step.error is not None
+        assert "too personal" in judge_step.error
+
+    async def test_step_judge_llm_failure_still_records_error(self):
+        """Judge agent failures should still propagate the underlying error."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.agents.base import AgentResult
+
+        pipeline = GenerationPipeline()
+        pipeline._judge_agent = MagicMock()
+        pipeline._judge_agent.run = AsyncMock(
+            return_value=AgentResult(
+                success=False,
+                error="OpenRouter 401 unauthorized",
+                latency_ms=12,
+            )
+        )
+
+        state = PipelineState(query="anything")
+        state = await pipeline._step_judge(state)
+
+        judge_step = state.get_step_result(PipelineStep.JUDGE)
+        assert judge_step is not None
+        assert judge_step.success is False
+        assert judge_step.error == "OpenRouter 401 unauthorized"
 
 
 @pytest.mark.fast


### PR DESCRIPTION
Closes el-38cej (plan el-3wuc). Owner found a timepoint generation that returned status=failed, error='Unknown error' — the catch-all swallowed the real cause. This propagates the actual exception so failures are diagnosable.