### PR TITLE
fix(judge): defensive override when LLM rejects with forbidden reasons (P0)

### DIFF
--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -1245,6 +1245,43 @@ class GenerationPipeline:
             # Create a failed judge result
             state.judge_result = JudgeAgent.create_failed_result(result.error)
 
+        # Defensive override: the SYSTEM_PROMPT explicitly says personal-future
+        # scenarios, speculative queries, and uncertain-outcome queries ARE the
+        # core product and MUST be accepted. The LLM occasionally drifts and
+        # rejects exactly those queries using the very keywords the prompt
+        # forbids ("speculative", "personal", "future", "uncertain outcome",
+        # "lacks concrete details", "prediction rather than descriptive scenario").
+        # When the judge rejects with one of those drift-class reasons, override
+        # is_valid back to true so the pipeline proceeds. Real rejections (pure
+        # data prediction, abstract concepts, technical how-to) use different
+        # rejection vocabulary and pass through normally.
+        if (
+            result.success
+            and state.judge_result is not None
+            and not state.judge_result.is_valid
+        ):
+            drift_reason = (state.judge_result.reason or "").lower()
+            DRIFT_KEYWORDS = (
+                "speculative",
+                "personal",
+                "future event",
+                "uncertain outcome",
+                "lacks concrete",
+                "prediction rather than",
+                "highly personal",
+            )
+            if any(kw in drift_reason for kw in DRIFT_KEYWORDS):
+                logger.warning(
+                    "Judge drift override: query rejected with forbidden reason "
+                    "(%s) — accepting per SYSTEM_PROMPT contract.",
+                    state.judge_result.reason,
+                )
+                # Mutate the result to valid + flag the override
+                state.judge_result.is_valid = True
+                state.judge_result.reason = (
+                    f"[director-override: judge-drift] {state.judge_result.reason}"
+                )
+
         # If the judge ran successfully but rejected the query as invalid, we
         # still want the rejection reason to surface as a step-level error so
         # the failed timepoint's error_message is informative instead of an

--- a/app/prompts/judge.py
+++ b/app/prompts/judge.py
@@ -8,9 +8,15 @@ Examples:
 """
 
 SYSTEM_PROMPT = """You are a temporal query validator for TIMEPOINT, an AI system that generates
-immersive visual scenes from historical and temporal moments.
+immersive visual scenes from moments in time — past, present, or future.
 
-Your task is to validate whether a query can be transformed into a compelling visual scene.
+TIMEPOINT's core product is SYNTHETIC TIME TRAVEL. Users preview moments that haven't happened
+yet: their investor pitch, a hard conversation, a job interview, a first date, a big negotiation.
+This is the PRIMARY use case. Future-event and personal-future queries are the product.
+
+Your task is to validate whether a query can be transformed into a compelling visual scene with
+actors, setting, dialog, and stakes. When in doubt, ACCEPT — a scene that tried is far better
+than a rejection that kills the experience.
 
 VALID queries include:
 - Historical events: "signing of the declaration of independence", "battle of thermopylae"
@@ -18,14 +24,38 @@ VALID queries include:
 - Fictional scenes: "the red wedding from game of thrones"
 - Speculative history: "what if napoleon won at waterloo"
 - Contemporary events: "moon landing 1969"
+- FUTURE PERSONAL SCENARIOS (core product): any query where the user is previewing a
+  moment they will face or want to simulate, even if it is personal, future, or uncertain.
+  Examples that MUST be accepted:
+    - "My Series A investor pitch — three skeptical partners asking hard questions about burn rate"
+    - "Hard conversation with my co-founder about equity"
+    - "Job interview at Google for senior engineer role"
+    - "Asking my boss for a raise"
+    - "First meeting with a new client who is skeptical"
+    - "My TED talk — the moment right before I walk on stage"
+    - Any preset like "Investor pitch", "Hard conversation", "Moon landing"
 
-INVALID queries include:
-- Abstract concepts without temporal context: "love", "happiness"
-- Technical questions: "how does a car engine work"
-- Personal queries: "what should I eat today"
-- Queries too vague to visualize: "something interesting"
+INVALID queries are ONLY those where literally nothing can be rendered as a scene:
+- Pure data / prediction requests with no actor, setting, or human stakes:
+    "predict next week's AAPL stock price"
+    "what are tomorrow's lottery numbers"
+- Completely abstract concepts with no scene context: "love", "happiness", "infinity"
+- Technical how-to questions: "how does a car engine work"
+- Preference queries with no scenario: "what should I eat today"
 
-=== CRITICAL: TEMPORAL PRECISION ===
+DO NOT reject a query because it is:
+- Personal (personal scenarios ARE the product)
+- About a future event (future events ARE the product)
+- Speculative or uncertain in outcome (all futures are uncertain — that is the point)
+- Lacking a specific date (approximate or implied time is fine)
+- About the user themselves (first-person scenarios are explicitly supported)
+
+A query is valid if it describes a moment with at least:
+- One or more people (including the user as a participant)
+- An implied setting or situation
+- Some stakes or tension
+
+=== CRITICAL: TEMPORAL PRECISION FOR HISTORICAL QUERIES ===
 
 Many historical queries are AMBIGUOUS and lead to era confusion. You MUST:
 
@@ -40,9 +70,10 @@ Many historical queries are AMBIGUOUS and lead to era confusion. You MUST:
    - Tudor England (1485-1603) is OFTEN confused with Stuart England (1603-1714)
 
 3. When cleaning queries, EXPLICITLY add:
-   - Specific year or date range
-   - Geographic location
-   - Key distinguishing features of the period
+   - Specific year or date range (for historical; for future queries use "near future" or the
+     implied timeframe)
+   - Geographic location or setting type
+   - Key distinguishing features of the period or scenario
 
 4. FLAG high-risk queries that may cause concept bleed:
    - Any query involving French Revolution, Roman Republic, Napoleonic era
@@ -51,10 +82,16 @@ Many historical queries are AMBIGUOUS and lead to era confusion. You MUST:
 
 For VALID queries:
 1. Clean and improve the query for better generation
-2. Extract any dates, locations, or historical figures mentioned
-3. Classify the query type (historical, fictional, speculative, contemporary)
+2. Extract any dates, locations, or figures mentioned
+3. Classify the query type:
+   - historical: real past event
+   - fictional: from a book/film/game
+   - speculative: counterfactual "what if"
+   - contemporary: modern/recent event
+   - personal_future: user's own future scenario, pitch, conversation, interview, etc.
 4. Rate your confidence (0-1)
-5. ADD TEMPORAL PRECISION if the query is ambiguous
+5. For personal_future queries: expand the scene details (who is in the room, what the
+   stakes are, what the setting looks like) so the generation pipeline can build a rich scene
 
 For INVALID queries:
 1. Explain why it cannot be visualized
@@ -66,21 +103,24 @@ USER_PROMPT_TEMPLATE = """Validate this temporal query for scene generation:
 
 Query: "{query}"
 
-Determine if this query can be transformed into a visual historical/temporal scene.
-If valid, clean up the query and extract any temporal/location hints.
+Determine if this query can be transformed into a visual scene with actors, setting, dialog,
+and stakes. Remember: personal future scenarios (investor pitches, hard conversations, job
+interviews, negotiations) are the core product — accept them.
+
+If valid, clean up the query and expand it with scene context.
 If invalid, explain why and suggest alternatives.
 
 Respond with valid JSON matching this schema:
 {{
   "is_valid": boolean,
-  "query_type": "historical" | "fictional" | "speculative" | "contemporary" | "invalid",
-  "cleaned_query": "improved query text",
+  "query_type": "historical" | "fictional" | "speculative" | "contemporary" | "personal_future" | "invalid",
+  "cleaned_query": "improved query text with expanded scene context",
   "confidence": 0.0-1.0,
   "reason": "explanation if invalid" | null,
   "suggested_query": "alternative suggestion" | null,
   "detected_year": integer | null,
-  "detected_location": "location string" | null,
-  "detected_figures": ["list", "of", "names"]
+  "detected_location": "location string or setting description" | null,
+  "detected_figures": ["list", "of", "names or roles"]
 }}"""
 
 

--- a/app/schemas/judge.py
+++ b/app/schemas/judge.py
@@ -32,9 +32,10 @@ class QueryType(str, Enum):
 
     HISTORICAL = "historical"  # Real historical event
     FICTIONAL = "fictional"  # Fictional/literary scene
-    SPECULATIVE = "speculative"  # "What if" scenarios
+    SPECULATIVE = "speculative"  # "What if" / counterfactual scenarios
     CONTEMPORARY = "contemporary"  # Modern/recent events
-    INVALID = "invalid"  # Not a valid temporal query
+    PERSONAL_FUTURE = "personal_future"  # User's own future scenario (pitch, conversation, etc.)
+    INVALID = "invalid"  # Not a valid temporal query — nothing can be rendered
 
 
 class JudgeResult(BaseModel):

--- a/tests/unit/test_agents/test_agents.py
+++ b/tests/unit/test_agents/test_agents.py
@@ -105,6 +105,64 @@ class TestJudgeAgent:
         assert result.query_type == QueryType.INVALID
         assert result.reason == "API timeout"
 
+    def test_system_prompt_allows_future_events(self):
+        """System prompt must explicitly allow future personal scenarios.
+
+        This is the core product — synthetic time travel for future events.
+        The prompt must not describe 'personal' or 'future' queries as invalid.
+        """
+        agent = JudgeAgent()
+        prompt = agent.get_system_prompt()
+        # Must explicitly mention personal_future as valid
+        assert "personal_future" in prompt
+        # Must mention investor pitch as a concrete example
+        assert "investor pitch" in prompt.lower() or "pitch" in prompt.lower()
+        # Must NOT classify future events as invalid by default
+        assert "future events are invalid" not in prompt.lower()
+        assert "personal queries" not in prompt.lower() or "personal future" in prompt.lower()
+
+    def test_user_prompt_includes_personal_future_type(self):
+        """User prompt schema must list personal_future as a valid query_type."""
+        agent = JudgeAgent()
+        prompt = agent.get_prompt("my series a pitch")
+        assert "personal_future" in prompt
+
+    @pytest.mark.asyncio
+    async def test_run_personal_future_query(self):
+        """Future personal scenarios must be accepted as personal_future type.
+
+        This is the core sell: 'synthetic time travel for future events.'
+        The failing query from prod was: 'My Series A investor pitch — preview exactly
+        how it unfolds.' The judge must accept this kind of query.
+        """
+        mock_router = MagicMock()
+        mock_router.call_structured = AsyncMock(
+            return_value=LLMResponse(
+                content=JudgeResult(
+                    is_valid=True,
+                    query_type=QueryType.PERSONAL_FUTURE,
+                    cleaned_query=(
+                        "Series A investor pitch meeting — three skeptical partners "
+                        "questioning burn rate and path to profitability, conference room setting"
+                    ),
+                    confidence=0.92,
+                ),
+                model="test-model",
+                provider=ProviderType.GOOGLE,
+            )
+        )
+
+        agent = JudgeAgent(router=mock_router)
+        result = await agent.run(
+            "My Series A investor pitch — three skeptical partners asking hard questions "
+            "about burn rate and path to profitability"
+        )
+
+        assert result.success is True
+        assert result.content.is_valid is True
+        assert result.content.query_type == QueryType.PERSONAL_FUTURE
+        assert result.metadata["is_valid"] is True
+
 
 # Timeline Agent Tests
 


### PR DESCRIPTION
Two confirmed prod-killing rejections 2026-05-18 on core product (synthetic future-event simulation). Judge LLM drifts + rejects queries the SYSTEM_PROMPT explicitly accepts. Adds keyword-based override that flips is_valid back to true when rejection vocabulary matches the drift class. Real rejections (data predictions, abstract concepts, how-to) use different vocab and still fail correctly.

Closes el-6b8u7.