### PR TITLE
fix: restore green CI — ruff format + judge-drift test conflict

### DIFF
--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -109,9 +109,7 @@ async def resolve_user(
     except IntegrityError:
         # Race: concurrent /resolve won. Roll back, re-fetch, return existing.
         await session.rollback()
-        result = await session.execute(
-            select(User).where(User.external_id == request.external_id)
-        )
+        result = await session.execute(select(User).where(User.external_id == request.external_id))
         user = result.scalar_one()
         logger.info(
             f"Resolve race for external_id={request.external_id}; returning existing {user.id}"

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -1255,11 +1255,7 @@ class GenerationPipeline:
         # is_valid back to true so the pipeline proceeds. Real rejections (pure
         # data prediction, abstract concepts, technical how-to) use different
         # rejection vocabulary and pass through normally.
-        if (
-            result.success
-            and state.judge_result is not None
-            and not state.judge_result.is_valid
-        ):
+        if result.success and state.judge_result is not None and not state.judge_result.is_valid:
             drift_reason = (state.judge_result.reason or "").lower()
             DRIFT_KEYWORDS = (
                 "speculative",

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -482,10 +482,14 @@ class TestStepJudgeRejection:
         pipeline = GenerationPipeline()
         # Avoid real router/agent initialization
         pipeline._judge_agent = MagicMock()
+        # Use a genuine (non-drift-class) rejection reason. Drift-class reasons
+        # (e.g. "too personal", "speculative") are intentionally overridden back
+        # to valid by _step_judge's defensive override; a real rejection such as
+        # a technical how-to request is not.
         rejected = JudgeResult(
             is_valid=False,
             query_type=QueryType.INVALID,
-            reason="Query is too personal to render as a scene",
+            reason="Query is a technical how-to request, not a scene",
         )
         pipeline._judge_agent.run = AsyncMock(
             return_value=AgentResult(
@@ -496,7 +500,7 @@ class TestStepJudgeRejection:
             )
         )
 
-        state = PipelineState(query="my wife's 43rd birthday")
+        state = PipelineState(query="how do I reset my router password")
         state = await pipeline._step_judge(state)
 
         assert state.is_valid is False
@@ -506,7 +510,7 @@ class TestStepJudgeRejection:
         # error reporting sees it as a real failure, not a silent invalidation.
         assert judge_step.success is False
         assert judge_step.error is not None
-        assert "too personal" in judge_step.error
+        assert "technical how-to" in judge_step.error
 
     async def test_step_judge_llm_failure_still_records_error(self):
         """Judge agent failures should still propagate the underlying error."""


### PR DESCRIPTION
## Root causes

Tests workflow has been red since 2026-05-18 across two jobs.

**Code Quality Checks** — `ruff format --check` flagged `app/api/v1/users.py` and `app/core/pipeline.py`. Both files carried unformatted long lines introduced by recent commits (#52 idempotent `/resolve`, #51 judge-drift override) that were not run through `ruff format`.

**Fast Unit Tests** — `test_step_judge_rejection_populates_step_error` failed with `assert True is False`. The test fed the query "my wife's 43rd birthday" with rejection reason "Query is too personal to render as a scene". The new judge-drift defensive override (#51) intentionally detects drift-class keywords like "personal" and flips `is_valid` back to `True`, so the judge rejection no longer registers as a step failure.

## Changes

- Ran `ruff format` on the two flagged files (whitespace/line-wrap only).
- Updated the test to use a genuine, non-drift rejection (a technical how-to query) so it continues to verify that real judge rejections surface a step-level error — without weakening or skipping the test.

## Verification

- `ruff check app/ tests/` and `ruff format --check app/ tests/` pass.
- `pytest -m fast` — 715 passed, 246 deselected.