### PR TITLE
fix: persist quick-sim future-moment timepoints to Flash DB

### DIFF
--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -56,7 +56,8 @@ from app.auth.credits import CREDIT_COSTS, grant_credits, spend_credits
 from app.auth.dependencies import get_current_user
 from app.config import QualityPreset
 from app.core.pipeline import GenerationPipeline
-from app.database import get_db_session
+from app.database import get_db_session, get_session
+from app.models import TimepointVisibility
 from app.models_auth import TransactionType, User
 from app.schemas.quick_sim import (
     OpportunityIn,
@@ -275,6 +276,68 @@ def summarize_tdf_for_metrics(tdf: dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Per-opportunity persistence
+# ---------------------------------------------------------------------------
+
+
+async def _persist_quick_sim_timepoint(
+    timepoint: Any,
+    *,
+    user_id: str | None,
+) -> str | None:
+    """Save a quick-sim future-moment Timepoint to Flash's DB.
+
+    Quick-sim returns a generated UUID + slug to the web-app, which uses
+    them to build a "Preview the moment" link at
+    ``/timepoint/{slug}?id={timepoint_id}``. That link resolves via Flash's
+    ``GET /api/v1/timepoints/{id}`` — which 404s unless we actually save
+    the row here. (Diagnosed against run 31:
+    ``5305ea61-b806-4046-979e-db1102ae6f93`` was never in the DB.)
+
+    The row is owned by the requesting user and marked PRIVATE — these are
+    per-run private simulations, not curated public timepoints. Visibility
+    inheritance follows the same pattern as
+    ``/timepoints/generate/sync`` (see :mod:`app.api.v1.timepoints`).
+
+    Uses a fresh ``get_session()`` rather than the request-scoped session
+    because the batch handler runs up to ``_BATCH_CONCURRENCY`` of these
+    concurrently and the request session is also being used for credit
+    ledger writes.
+
+    On any DB error this returns ``None`` (and logs) so the quick-sim
+    response still carries the in-memory ``tdf`` — the only loss is the
+    Preview link, which the web-app suppresses when ``timepoint_id`` is
+    absent.
+    """
+    try:
+        if user_id is not None:
+            timepoint.user_id = user_id
+            # Quick-sim moments are per-user private simulations.
+            timepoint.visibility = TimepointVisibility.PRIVATE
+        else:
+            # Anonymous quick-sim (AUTH_ENABLED=false) — nobody owns the row,
+            # so PRIVATE would lock it out of GET /timepoints/{id} forever
+            # (check_visibility_access 403s when there is no owner). Keep it
+            # PUBLIC so the Preview link still resolves.
+            timepoint.visibility = TimepointVisibility.PUBLIC
+
+        async with get_session() as session:
+            session.add(timepoint)
+            await session.commit()
+            await session.refresh(timepoint)
+            return timepoint.id
+    except Exception as exc:  # noqa: BLE001 — persistence is best-effort
+        logger.warning(
+            "quick_sim: failed to persist timepoint id=%s slug=%s user=%s: %s",
+            getattr(timepoint, "id", None),
+            getattr(timepoint, "slug", None),
+            user_id,
+            exc,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Per-opportunity simulation
 # ---------------------------------------------------------------------------
 
@@ -341,9 +404,19 @@ async def _simulate_one(
         )
 
         timepoint = pipeline.state_to_timepoint(state)
+        # Persist the quick-sim future-moment so web-app's "Preview the moment"
+        # link (which points at /timepoint/{slug}?id={timepoint_id}) can resolve
+        # via GET /api/v1/timepoints/{id}. Without this row, every Preview
+        # click 404s — see fix-quick-sim-persist-timepoints-2026-05-27.
+        # Quick-sim moments are private to the requesting user (not user-curated
+        # public timepoints), so visibility=PRIVATE. Persist failure must NOT
+        # fail the quick-sim: log + clear timepoint_id so the web-app skips
+        # rendering the Preview link.
+        persisted_id = await _persist_quick_sim_timepoint(timepoint, user_id=user_id)
+
         tdf = dict(timepoint.tdf_payload or {})
         tdf["status"] = timepoint.status.value if timepoint.status else "unknown"
-        tdf["timepoint_id"] = timepoint.id
+        tdf["timepoint_id"] = persisted_id  # None if persistence failed
         tdf["slug"] = timepoint.slug
 
         scene_context = summarize_tdf_for_metrics(tdf)

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -863,3 +863,54 @@ class TestEndpointRegistered:
             },
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Quick-sim timepoint persistence (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestQuickSimPersistence:
+    """Quick-sim timepoints must be persisted to Flash's DB.
+
+    Regression test for fix-quick-sim-persist-timepoints-2026-05-27. The
+    handler used to build a Timepoint with a generated UUID + slug, return
+    them to the web-app, but never call ``session.add`` — so every
+    web-app "Preview the moment" link 404'd via
+    ``GET /api/v1/timepoints/{id}``. This test exercises the persistence
+    helper against a real test DB (no mocks) and then re-reads via the
+    public GET endpoint to assert the round-trip works.
+    """
+
+    async def test_persist_then_get_via_api_round_trips(self, test_client):
+        """`_persist_quick_sim_timepoint` saves the row; GET /timepoints/{id}
+        then returns 200 with the same slug."""
+        from app.api.v1.find_money import _persist_quick_sim_timepoint
+        from app.models import Timepoint, TimepointStatus, TimepointVisibility
+
+        tp = Timepoint.create(
+            query="$50k climate operating grant by Sept 2026",
+            status=TimepointStatus.COMPLETED,
+            tdf_payload={"query": "$50k climate operating grant", "scene_data": {}},
+            tdf_hash="quicksim-test-hash",
+            year=2026,
+        )
+
+        persisted_id = await _persist_quick_sim_timepoint(tp, user_id=None)
+
+        assert persisted_id is not None, "quick-sim timepoint must be persisted"
+        assert persisted_id == tp.id
+
+        # The round-trip through the real GET handler is the bug: before
+        # this fix the GET 404'd because the row was never saved.
+        resp = await test_client.get(f"/api/v1/timepoints/{persisted_id}")
+        assert resp.status_code == 200, (
+            f"expected 200 from GET /api/v1/timepoints/{persisted_id}, "
+            f"got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        assert body["id"] == persisted_id
+        assert body["slug"] == tp.slug
+        # Anonymous quick-sim (user_id=None) persists as PUBLIC so the
+        # Preview link is reachable; authenticated runs persist as PRIVATE.
+        assert body.get("visibility") == TimepointVisibility.PUBLIC.value


### PR DESCRIPTION
## Summary

The `/api/v1/find-money/quick-sim-batch` handler built a `Timepoint` via `pipeline.state_to_timepoint()` with a generated UUID + slug and returned both to the web-app, but **never persisted them**. The web-app's Find Money result cards build "Preview the moment" links pointing at `/timepoint/{slug}?id={timepoint_id}`, which resolve via Flash's `GET /api/v1/timepoints/{id}` — so every click 404'd because the row was never in the DB.

Diagnosed against run 31: timepoint id `5305ea61-b806-4046-979e-db1102ae6f93` was never present in the Flash DB.

## Changes

- New `_persist_quick_sim_timepoint()` helper called from `_simulate_one()` right after `state_to_timepoint()`.
- Visibility: `PRIVATE` when the request is authenticated; `PUBLIC` when `user_id is None` (AUTH_ENABLED=false). PRIVATE without an owner would 403 on every GET, defeating the Preview link.
- Persistence uses a fresh `get_session()` rather than the request-scoped session — the batch runs up to `_BATCH_CONCURRENCY` of these concurrently and the request session is also doing credit-ledger writes.
- Persist failure is non-fatal: log + return `None`. The response then sets `timepoint_id=None` so the web-app suppresses the Preview link rather than rendering a known-404. Quick-sim metrics still flow.

## Test plan

- [ ] CI green (new regression test under `tests/unit/test_api_find_money.py::TestQuickSimPersistence`)
- [ ] Regression test exercises `_persist_quick_sim_timepoint` against a real test DB (no mocks) and asserts `GET /api/v1/timepoints/{id}` returns 200 with the matching slug
- [ ] Manual: post-merge, a fresh find-money run from the web-app should resolve Preview links instead of 404ing