### PR TITLE
feat(find-money): quick-sim depth dial + FRONTIER preset (Claude Opus 4)

### DIFF
--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -142,8 +142,52 @@ _BATCH_CONCURRENCY = 6
 # The ``preset`` the caller passes still flows through (it selects the
 # parallelism mode), but the text model + thinking config below override
 # it so quick-sim stays fast regardless of which preset the web-app sends.
+#
+# Callers may opt into a different model tier by passing the ``depth``
+# field (Operation Control Surface dial — B1 spec).  When ``depth`` is
+# absent the default below applies unchanged (no regression).
 _QUICK_SIM_TEXT_MODEL = "gemini-2.5-flash"
 _QUICK_SIM_LLM_PARAMS: dict[str, Any] = {"thinking_level": 512, "max_tokens": 4096}
+
+# Operation Control Surface dial → text model resolution for quick-sim.
+# Maps the B1 ``depth`` values to concrete model IDs.  The thinking-level
+# cap (``thinking_level=512``) is applied uniformly; non-Gemini providers
+# (OpenRouter/Claude) safely ignore that key — it never reaches their
+# payload (see ``app/core/providers/openrouter.py`` kwargs handling).
+#
+# Depth → model rationale:
+#   fast     — gemini-2.0-flash (no thinking overhead, ~2-4s/call; good for bulk)
+#   standard — gemini-2.5-flash (current default; unchanged)
+#   deep     — gemini-2.5-flash (same text model as BALANCED/HD; richer image in full render)
+#   frontier — anthropic/claude-opus-4 (true frontier; Anthropic-direct via OpenRouter for cache)
+_DEPTH_TO_TEXT_MODEL: dict[str, str] = {
+    "fast": "gemini-2.0-flash",
+    "standard": "gemini-2.5-flash",
+    "deep": "gemini-2.5-flash",
+    "frontier": "anthropic/claude-opus-4",
+}
+
+
+def _resolve_quick_sim_text_model(depth: str | None) -> str:
+    """Return the text model to use for a quick-sim call given an optional depth tier.
+
+    Falls back to :data:`_QUICK_SIM_TEXT_MODEL` when ``depth`` is absent
+    or unrecognised, preserving today's default behaviour (no regression).
+
+    Args:
+        depth: One of ``"fast"``, ``"standard"``, ``"deep"``, ``"frontier"``,
+            or ``None``.
+
+    Returns:
+        A model ID string accepted by :class:`GenerationPipeline`.
+    """
+    if depth is None:
+        return _QUICK_SIM_TEXT_MODEL
+    resolved = _DEPTH_TO_TEXT_MODEL.get(depth.lower())
+    if resolved is None:
+        logger.warning("quick_sim: unrecognised depth %r, using default model", depth)
+        return _QUICK_SIM_TEXT_MODEL
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -494,6 +538,7 @@ async def _simulate_one(
     opportunity: OpportunityIn,
     preset: QualityPreset | None,
     user_id: str | None,
+    depth: str | None = None,
 ) -> dict[str, Any]:
     """Run the quick-sim pipeline + metrics agent for a single opportunity.
 
@@ -508,6 +553,11 @@ async def _simulate_one(
     Because the light path never renders an image, the request's
     ``generate_image`` flag does not apply to quick-sim and is ignored.
 
+    The ``depth`` parameter selects the text/judge model via
+    :func:`_resolve_quick_sim_text_model`.  When absent, the default
+    :data:`_QUICK_SIM_TEXT_MODEL` (``gemini-2.5-flash``) is used and
+    behaviour is identical to previous versions (no regression).
+
     Returns a dict ready to fold into a :class:`QuickSimTdfEntry`:
     ``{"success": bool, "tdf": dict | None, "quick_sim": QuickSimMetrics | None,
        "error": str | None, "latency_ms": int}``.
@@ -519,15 +569,21 @@ async def _simulate_one(
     t0 = time.perf_counter()
     opp_dict = opportunity.model_dump()
 
+    # Resolve the text model from the depth dial (B1 spec). Falls back to
+    # the module-level default when depth is absent or unrecognised.
+    text_model = _resolve_quick_sim_text_model(depth)
+
     # Lazy import — avoids pulling app.prompts at module import time, which
     # would force the test conftest to set every env var early.
     from app.prompts.quick_sim import build_future_moment_query
 
     query = build_future_moment_query(goal=goal, opportunity=opp_dict)
     logger.info(
-        "quick_sim: opportunity %d title=%r query=%r",
+        "quick_sim: opportunity %d title=%r depth=%r model=%r query=%r",
         index,
         opp_dict.get("title"),
+        depth,
+        text_model,
         query[:120],
     )
 
@@ -535,7 +591,7 @@ async def _simulate_one(
         pipeline = _build_generation_pipeline(
             preset=preset,
             user_id=user_id,
-            text_model=_QUICK_SIM_TEXT_MODEL,
+            text_model=text_model,
             llm_params=dict(_QUICK_SIM_LLM_PARAMS),
         )
         # LIGHT path: run_quick_sim runs only Judge -> Timeline -> Scene ->
@@ -582,10 +638,13 @@ async def _simulate_one(
 
         scene_context = summarize_tdf_for_metrics(tdf)
 
-        # The metrics agent reuses the pipeline's router (same fast,
-        # Google-native text path) AND the same capped thinking budget —
-        # without _QUICK_SIM_LLM_PARAMS it would fall back to the model's
-        # dynamic thinking budget and become the slowest step in the path.
+        # The metrics agent reuses the pipeline's router (same model as the
+        # pipeline, selected by the depth dial) AND the same capped LLM
+        # params — without _QUICK_SIM_LLM_PARAMS it would fall back to the
+        # model's dynamic thinking budget (for Gemini thinking models) and
+        # become the slowest step in the path. For non-Gemini providers
+        # (e.g. frontier/Claude), thinking_level is ignored at the provider
+        # layer, so the same params dict is safe to pass unconditionally.
         metrics_agent = QuickSimMetricsAgent(
             router=pipeline.router,
             llm_params=dict(_QUICK_SIM_LLM_PARAMS),
@@ -769,6 +828,10 @@ async def _run_batch(
     Up to :data:`_BATCH_CONCURRENCY` opportunities run at once; the
     response lists one :class:`QuickSimTdfEntry` per opportunity,
     ordered by request index, so it always pairs 1:1 with the request.
+
+    The ``request.depth`` field (Operation Control Surface dial) is
+    forwarded to :func:`_simulate_one`, which resolves it to a concrete
+    text model via :func:`_resolve_quick_sim_text_model`.
     """
     preset: QualityPreset | None = None
     if request.preset:
@@ -817,6 +880,7 @@ async def _run_batch(
                 opportunity=opportunity,
                 preset=preset,
                 user_id=user_id,
+                depth=request.depth,
             )
             return index, opportunity, result, True
 
@@ -922,12 +986,14 @@ async def quick_sim_batch(
     gateway_metered = request.headers.get(_GATEWAY_METERED_HEADER, "").lower() == "true"
 
     logger.info(
-        "quick_sim_batch: goal=%r count=%d user=%s gateway_metered=%s preset=%s",
+        "quick_sim_batch: goal=%r count=%d user=%s gateway_metered=%s preset=%s depth=%s model=%s",
         body.goal[:80],
         len(body.opportunities),
         user.id if user else None,
         gateway_metered,
         body.preset,
+        body.depth,
+        _resolve_quick_sim_text_model(body.depth),
     )
 
     response = await _run_batch(

--- a/app/config.py
+++ b/app/config.py
@@ -51,11 +51,12 @@ class ParallelismMode(str, Enum):
 class QualityPreset(str, Enum):
     """Quality preset for generation pipeline.
 
-    - HD: Highest quality with Gemini 3 Pro + Google image generation
+    - HD: Highest quality with Gemini 2.5 Flash + Nano Banana Pro image
     - HYPER: Fastest speed with Gemini 2.0 Flash via OpenRouter
     - BALANCED: Default balance of quality and speed
     - GEMINI3: Latest Gemini 3 Flash Preview via OpenRouter (thinking model)
     - FREE_DISTILLABLE: Free distillable models — $0 cost, outputs usable for training/distillation
+    - FRONTIER: True frontier — Claude Opus 4 via OpenRouter/Anthropic-direct (high-judgment tasks)
     """
 
     HD = "hd"
@@ -63,6 +64,7 @@ class QualityPreset(str, Enum):
     BALANCED = "balanced"
     GEMINI3 = "gemini3"
     FREE_DISTILLABLE = "free_distillable"
+    FRONTIER = "frontier"
 
 
 class Environment(str, Enum):
@@ -132,6 +134,8 @@ class VerifiedModels:
         # OpenRouter free distillable models
         "openrouter/hunter-alpha",
         "openrouter/healer-alpha",
+        # Anthropic frontier (Anthropic-direct routing via OpenRouter for cache)
+        "anthropic/claude-opus-4",
     ]
 
     # Fallback chains - ordered by preference
@@ -272,6 +276,27 @@ PRESET_CONFIGS: dict[QualityPreset, dict[str, Any]] = {
         "thinking_level": None,
         "image_supported": True,
     },
+    QualityPreset.FRONTIER: {
+        "name": "Frontier",
+        "description": (
+            "True frontier — Claude Opus 4 via OpenRouter with Anthropic-direct routing. "
+            "High-judgment tasks: entity grounding, judge passes, discrimination steps. "
+            "Uses json_mode (not json_schema). Prompt caching active via cache_control injection."
+        ),
+        # anthropic/claude-opus-4 routes through OpenRouter with provider.order=["Anthropic"]
+        # to guarantee Anthropic-direct (not Bedrock) routing, which is required for cache headers.
+        "text_model": "anthropic/claude-opus-4",
+        "judge_model": "anthropic/claude-opus-4",
+        "image_model": "gemini-3-pro-image-preview",  # HD image quality reused
+        "image_provider": ProviderType.GOOGLE,
+        "text_provider": ProviderType.OPENROUTER,
+        "openrouter_provider_order": ["Anthropic"],  # force Anthropic-direct for prompt cache
+        "json_schema_support": False,  # Claude via OpenRouter: use json_mode, not json_schema
+        "extended_thinking": False,  # pending OpenRouter verification; revisit when confirmed
+        "max_tokens": 4096,
+        "thinking_level": None,
+        "image_supported": True,
+    },
 }
 
 
@@ -283,6 +308,7 @@ PRESET_PARALLELISM: dict[QualityPreset, ParallelismMode] = {
     QualityPreset.HYPER: ParallelismMode.MAX,  # Speed focus, maximum parallelism
     QualityPreset.GEMINI3: ParallelismMode.AGGRESSIVE,  # Thinking model, moderate parallelism
     QualityPreset.FREE_DISTILLABLE: ParallelismMode.SEQUENTIAL,  # Free models need sequential
+    QualityPreset.FRONTIER: ParallelismMode.NORMAL,  # High-cost frontier; standard parallelism
 }
 
 # Provider rate limits (requests per minute and safe concurrent calls)

--- a/app/core/model_capabilities.py
+++ b/app/core/model_capabilities.py
@@ -410,6 +410,21 @@ TEXT_MODEL_REGISTRY: dict[str, TextModelConfig] = {
         max_output_tokens=8192,
         notes="Claude Sonnet 4.5 via OpenRouter (claude-3.5-sonnet was retired by Anthropic)",
     ),
+    "anthropic/claude-opus-4": TextModelConfig(
+        model_id="anthropic/claude-opus-4",
+        provider="openrouter",
+        supports_json_schema=False,  # Claude via OpenRouter: use json_mode, not json_schema
+        supports_json_mode=True,
+        supports_function_calling=True,
+        supports_streaming=True,
+        supports_extended_thinking=False,  # pending OpenRouter verification; revisit when confirmed
+        max_output_tokens=8192,
+        notes=(
+            "Claude Opus 4 via OpenRouter. FRONTIER preset. "
+            "Anthropic-direct routing (provider.order=[Anthropic]) required for prompt cache. "
+            "Bedrock routing blocks cache headers and must not be used."
+        ),
+    ),
     "openai/gpt-4o": TextModelConfig(
         model_id="openai/gpt-4o",
         provider="openrouter",

--- a/app/schemas/quick_sim.py
+++ b/app/schemas/quick_sim.py
@@ -82,6 +82,20 @@ class QuickSimBatchRequest(BaseModel):
         preset: Quality preset forwarded to the generation pipeline
             (default ``"hyper"`` — batch latency dominates UX, so we
             favour speed by default).
+        depth: Operation Control Surface dial value (``fast`` / ``standard`` /
+            ``deep`` / ``frontier``). When present, overrides the text and
+            judge model used by both the quick-sim render
+            (:meth:`GenerationPipeline.run_quick_sim`) and the
+            :class:`QuickSimMetricsAgent`, mapping::
+
+                fast     → gemini-2.0-flash (bulk/cheap)
+                standard → gemini-2.5-flash (current default, no change)
+                deep     → gemini-2.5-flash (same text model as standard; HD image in full render)
+                frontier → anthropic/claude-opus-4 (true frontier, Anthropic-direct routing)
+
+            Absent or ``None`` → today's default (``gemini-2.5-flash``), no regression.
+            The thinking-budget cap (``thinking_level=512``) is kept for Gemini thinking models
+            and naturally ignored by non-thinking providers (OpenRouter/Claude).
         generate_image: Whether to attach images to the future-moments.
             Default ``False`` — images add ~30s each and aren't needed
             for the decision page.
@@ -93,6 +107,14 @@ class QuickSimBatchRequest(BaseModel):
     preset: str | None = Field(
         default="hyper",
         description="Quality preset forwarded to GenerationPipeline (hyper/balanced/hd).",
+    )
+    depth: str | None = Field(
+        default=None,
+        description=(
+            "Operation Control Surface dial: fast|standard|deep|frontier. "
+            "Selects the text/judge model for quick-sim render + metrics agent. "
+            "Absent → gemini-2.5-flash default (no regression)."
+        ),
     )
     generate_image: bool = Field(
         default=False,

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -29,8 +29,10 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from app.api.v1.find_money import (
+    _QUICK_SIM_TEXT_MODEL,
     _build_generation_pipeline,
     _build_tdf_entry,
+    _resolve_quick_sim_text_model,
     summarize_tdf_for_metrics,
 )
 from app.config import QualityPreset
@@ -126,6 +128,15 @@ class TestQuickSimBatchRequest:
         assert req.goal == "$50k operating grant"
         assert req.preset == "hyper"  # default favours speed
         assert req.generate_image is False
+        assert req.depth is None  # dial absent → default model path
+
+    def test_depth_accepts_control_surface_tier(self):
+        req = QuickSimBatchRequest(
+            goal="$50k operating grant",
+            opportunities=self._opps(1),
+            depth="frontier",
+        )
+        assert req.depth == "frontier"
 
     def test_requires_at_least_one_opportunity(self):
         with pytest.raises(ValidationError):
@@ -146,6 +157,36 @@ class TestQuickSimBatchRequest:
     def test_goal_max_length(self):
         with pytest.raises(ValidationError):
             QuickSimBatchRequest(goal="x" * 1001, opportunities=self._opps(1))
+
+
+@pytest.mark.fast
+class TestResolveQuickSimTextModel:
+    """Operation Control Surface depth dial → text-model resolution (el-3ojoy).
+
+    The default (depth absent) path must be unchanged — this is the
+    no-regression contract for every existing quick-sim caller.
+    """
+
+    def test_none_uses_default_no_regression(self):
+        assert _resolve_quick_sim_text_model(None) == _QUICK_SIM_TEXT_MODEL
+
+    def test_standard_resolves_to_default_model(self):
+        assert _resolve_quick_sim_text_model("standard") == _QUICK_SIM_TEXT_MODEL
+
+    def test_fast_tier_uses_cheaper_model(self):
+        assert _resolve_quick_sim_text_model("fast") == "gemini-2.0-flash"
+
+    def test_deep_tier_uses_default_text_model(self):
+        assert _resolve_quick_sim_text_model("deep") == "gemini-2.5-flash"
+
+    def test_frontier_tier_uses_claude_opus(self):
+        assert _resolve_quick_sim_text_model("frontier") == "anthropic/claude-opus-4"
+
+    def test_depth_is_case_insensitive(self):
+        assert _resolve_quick_sim_text_model("FRONTIER") == "anthropic/claude-opus-4"
+
+    def test_unrecognised_depth_falls_back_to_default(self):
+        assert _resolve_quick_sim_text_model("ludicrous") == _QUICK_SIM_TEXT_MODEL
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary
Implements the **Operation Control Surface depth dial** for quick-sim (task **el-3ojoy** / spec el-17z9r) — the model-control surface that lets callers choose a model tier per batch.

- `QuickSimBatchRequest.depth` (optional): `fast` | `standard` | `deep` | `frontier`.
- `_resolve_quick_sim_text_model(depth)` maps the tier to a concrete text model and is threaded through `_run_batch → _simulate_one` for both the quick-sim render and the metrics agent.
- New `FRONTIER` QualityPreset + `anthropic/claude-opus-4` registered in `VerifiedModels` and `TEXT_MODEL_REGISTRY` (OpenRouter, Anthropic-direct routing for prompt cache; `json_mode` not `json_schema`).

**No regression:** `depth` defaults to `None` → the existing `gemini-2.5-flash` path is unchanged. The frontier tier is opt-in and not yet wired through the web-app (that's C2/el-1u4zg).

## Follow-up (non-blocking)
Verify the exact frontier OpenRouter slug before the tier is exposed to users: flash uses `anthropic/claude-opus-4`, while pro-cloud's apex is `anthropic/claude-opus-4-8`. Default path is unaffected either way.

## Test plan
- [x] `tests/unit/test_api_find_money.py` — added `TestResolveQuickSimTextModel` (mapping, case-insensitivity, default fallback) + `depth` schema tests. 74 passed, no mocks.