### PR TITLE
fix(find-money): frontier model slug -> anthropic/claude-opus-4.8 (valid OpenRouter)

### DIFF
--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -159,12 +159,12 @@ _QUICK_SIM_LLM_PARAMS: dict[str, Any] = {"thinking_level": 512, "max_tokens": 40
 #   fast     — gemini-2.0-flash (no thinking overhead, ~2-4s/call; good for bulk)
 #   standard — gemini-2.5-flash (current default; unchanged)
 #   deep     — gemini-2.5-flash (same text model as BALANCED/HD; richer image in full render)
-#   frontier — anthropic/claude-opus-4 (true frontier; Anthropic-direct via OpenRouter for cache)
+#   frontier — anthropic/claude-opus-4.8 (true frontier; Anthropic-direct via OpenRouter for cache)
 _DEPTH_TO_TEXT_MODEL: dict[str, str] = {
     "fast": "gemini-2.0-flash",
     "standard": "gemini-2.5-flash",
     "deep": "gemini-2.5-flash",
-    "frontier": "anthropic/claude-opus-4",
+    "frontier": "anthropic/claude-opus-4.8",
 }
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -135,7 +135,7 @@ class VerifiedModels:
         "openrouter/hunter-alpha",
         "openrouter/healer-alpha",
         # Anthropic frontier (Anthropic-direct routing via OpenRouter for cache)
-        "anthropic/claude-opus-4",
+        "anthropic/claude-opus-4.8",
     ]
 
     # Fallback chains - ordered by preference
@@ -279,14 +279,14 @@ PRESET_CONFIGS: dict[QualityPreset, dict[str, Any]] = {
     QualityPreset.FRONTIER: {
         "name": "Frontier",
         "description": (
-            "True frontier — Claude Opus 4 via OpenRouter with Anthropic-direct routing. "
+            "True frontier — Claude Opus 4.8 via OpenRouter with Anthropic-direct routing. "
             "High-judgment tasks: entity grounding, judge passes, discrimination steps. "
             "Uses json_mode (not json_schema). Prompt caching active via cache_control injection."
         ),
-        # anthropic/claude-opus-4 routes through OpenRouter with provider.order=["Anthropic"]
+        # anthropic/claude-opus-4.8 routes through OpenRouter with provider.order=["Anthropic"]
         # to guarantee Anthropic-direct (not Bedrock) routing, which is required for cache headers.
-        "text_model": "anthropic/claude-opus-4",
-        "judge_model": "anthropic/claude-opus-4",
+        "text_model": "anthropic/claude-opus-4.8",
+        "judge_model": "anthropic/claude-opus-4.8",
         "image_model": "gemini-3-pro-image-preview",  # HD image quality reused
         "image_provider": ProviderType.GOOGLE,
         "text_provider": ProviderType.OPENROUTER,

--- a/app/core/model_capabilities.py
+++ b/app/core/model_capabilities.py
@@ -410,8 +410,8 @@ TEXT_MODEL_REGISTRY: dict[str, TextModelConfig] = {
         max_output_tokens=8192,
         notes="Claude Sonnet 4.5 via OpenRouter (claude-3.5-sonnet was retired by Anthropic)",
     ),
-    "anthropic/claude-opus-4": TextModelConfig(
-        model_id="anthropic/claude-opus-4",
+    "anthropic/claude-opus-4.8": TextModelConfig(
+        model_id="anthropic/claude-opus-4.8",
         provider="openrouter",
         supports_json_schema=False,  # Claude via OpenRouter: use json_mode, not json_schema
         supports_json_mode=True,
@@ -420,7 +420,7 @@ TEXT_MODEL_REGISTRY: dict[str, TextModelConfig] = {
         supports_extended_thinking=False,  # pending OpenRouter verification; revisit when confirmed
         max_output_tokens=8192,
         notes=(
-            "Claude Opus 4 via OpenRouter. FRONTIER preset. "
+            "Claude Opus 4.8 via OpenRouter. FRONTIER preset. "
             "Anthropic-direct routing (provider.order=[Anthropic]) required for prompt cache. "
             "Bedrock routing blocks cache headers and must not be used."
         ),

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -180,10 +180,10 @@ class TestResolveQuickSimTextModel:
         assert _resolve_quick_sim_text_model("deep") == "gemini-2.5-flash"
 
     def test_frontier_tier_uses_claude_opus(self):
-        assert _resolve_quick_sim_text_model("frontier") == "anthropic/claude-opus-4"
+        assert _resolve_quick_sim_text_model("frontier") == "anthropic/claude-opus-4.8"
 
     def test_depth_is_case_insensitive(self):
-        assert _resolve_quick_sim_text_model("FRONTIER") == "anthropic/claude-opus-4"
+        assert _resolve_quick_sim_text_model("FRONTIER") == "anthropic/claude-opus-4.8"
 
     def test_unrecognised_depth_falls_back_to_default(self):
         assert _resolve_quick_sim_text_model("ludicrous") == _QUICK_SIM_TEXT_MODEL


### PR DESCRIPTION
## Summary
Follow-up: verify/correct the frontier OpenRouter slug. The FRONTIER preset + quick-sim `depth` dial (added in #58) used `anthropic/claude-opus-4`, which on OpenRouter is the **original Opus 4.0**. Pinned to the latest Opus — **`anthropic/claude-opus-4.8`** — so the "frontier" tier is actually frontier, and reconciled with pro-cloud's `apex_model` (a sibling PR fixes its malformed `claude-opus-4-8` hyphen slug to `4.8`).

Verified `anthropic/claude-opus-4.8` is a valid slug via the OpenRouter models API (`anthropic/claude-opus-4` … `4.8` all exist; the bare `…-4` is 4.0). The frontier tier is not yet user-exposed (C2 deferred), so no live behavior change.

## Test plan
- [x] `tests/unit/test_api_find_money.py` 74 passed (resolver tests updated to assert `4.8`); ruff clean.