### PR TITLE
docs: remove private service references from ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,17 +291,9 @@ Render the past. Simulate the future. Score the predictions. Accumulate the grap
 |---------|------|------|------|
 | **Flash** | **Open Source** | **timepoint-flash** | **Reality Writer — renders grounded historical moments** |
 | **Clockchain** | Open Source | timepoint-clockchain | Temporal Causal Graph — Rendered Past + Rendered Future, growing 24/7 |
-| **Pro** | Closed / Hosted API | pro.timepointai.com | SNAG Simulation Engine — hosted temporal simulation, TDF output |
 | **Proteus** | Open Source | proteus | Settlement Layer — prediction markets for Rendered Futures |
 | **TDF** | Open Source | timepoint-tdf | Data Format — JSON-LD interchange across all services |
 | **SNAG Bench** | Open Source | timepoint-snag-bench | Quality Certifier — measures Causal Resolution across renderings |
-| **Billing** | Private | timepoint-billing | Payment Processing — Apple IAP + Stripe |
-| **MCP** | Private | timepoint-mcp | MCP Server — AI agent access to Flash and Clockchain |
-| **Web App** | Private | timepoint-web-app | Browser client at app.timepointai.com |
-| **Landing** | Private | timepoint-landing | Marketing site at timepointai.com |
-| **iPhone App** | Private | timepoint-iphone-app | iOS client — Synthetic Time Travel on mobile |
-| **API Gateway** | Private | timepoint-api-gateway | Reverse proxy at api.timepointai.com |
-| **Skip Meetings** | Private | skipmeetingsai | Meeting intelligence SaaS powered by Flash |
 
 ## License
 


### PR DESCRIPTION
Part of a coordinated sweep across the open-source engine repos. These public repos each republished a "Timepoint ecosystem" service-map table that named the **private** repos (API gateway, billing, web app, skipmeetings, Pro, landing, iPhone app) with their roles and production URLs — collectively disclosing the private backend architecture.

This removes those private rows while keeping the open-source siblings and the repo's own legitimate config docs. No secret values were involved (the leak was architectural, not credentials).