### PR TITLE
fix: ground judge/timeline/quick-sim prompts in current real-world date

### DIFF
--- a/app/prompts/judge.py
+++ b/app/prompts/judge.py
@@ -7,6 +7,8 @@ Examples:
     >>> prompt = get_prompt("signing of the declaration")
 """
 
+from app.prompts.temporal_grounding import current_date_grounding
+
 SYSTEM_PROMPT = """You are a temporal query validator for TIMEPOINT, an AI system that generates
 immersive visual scenes from moments in time — past, present, or future.
 
@@ -101,6 +103,8 @@ Respond with a JSON object matching the JudgeResult schema."""
 
 USER_PROMPT_TEMPLATE = """Validate this temporal query for scene generation:
 
+{current_date_grounding}
+
 Query: "{query}"
 
 Determine if this query can be transformed into a visual scene with actors, setting, dialog,
@@ -133,7 +137,10 @@ def get_prompt(query: str) -> str:
     Returns:
         Formatted user prompt
     """
-    return USER_PROMPT_TEMPLATE.format(query=query)
+    return USER_PROMPT_TEMPLATE.format(
+        query=query,
+        current_date_grounding=current_date_grounding(),
+    )
 
 
 def get_system_prompt() -> str:

--- a/app/prompts/quick_sim.py
+++ b/app/prompts/quick_sim.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.prompts.temporal_grounding import current_date_grounding
+
 # ---------------------------------------------------------------------------
 # Future-tense moment query (fed to GenerationPipeline as the user query)
 # ---------------------------------------------------------------------------
@@ -143,6 +145,10 @@ waste their money. Calibrate."""
 
 METRICS_USER_TEMPLATE = """Assess this opportunity for the user's goal.
 
+{current_date_grounding}
+Judge deadlines and timing risks against this date — a deadline in the past is a
+hard timing risk.
+
 USER GOAL:
 {goal}
 
@@ -192,6 +198,7 @@ def get_metrics_prompt(
         Formatted user prompt.
     """
     return METRICS_USER_TEMPLATE.format(
+        current_date_grounding=current_date_grounding(),
         goal=goal.strip(),
         title=(opportunity.get("title") or "unspecified").strip(),
         source_url=(opportunity.get("source_url") or "unspecified") or "unspecified",

--- a/app/prompts/temporal_grounding.py
+++ b/app/prompts/temporal_grounding.py
@@ -1,0 +1,44 @@
+"""Real-world current-date grounding for pipeline prompts.
+
+LLMs default to their training-data sense of "now" (often a past year),
+which breaks contemporary/personal-future queries that use relative
+expressions like "tomorrow" or "next Tuesday". This helper produces a
+grounding block, computed at request time, that prompts can embed so the
+model resolves relative dates against the actual current date.
+
+Examples:
+    >>> from app.prompts.temporal_grounding import current_date_grounding
+    >>> block = current_date_grounding()
+    >>> "Current real-world date:" in block
+    True
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def current_date_grounding(now: datetime | None = None) -> str:
+    """Build a current-date grounding block for prompt injection.
+
+    Args:
+        now: Override for the current datetime (must be timezone-aware);
+            defaults to the actual current UTC time.
+
+    Returns:
+        A short instruction block stating the real current date and how
+        to resolve relative temporal expressions against it.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+    weekday = now.strftime("%A")
+    return (
+        f"Current real-world date: {date_str} ({weekday}, UTC). "
+        'Relative temporal expressions in the query — "today", "tomorrow", '
+        '"next Tuesday", "in two weeks", "this summer" — MUST be resolved '
+        "against this date, NOT against your training data. For contemporary "
+        "or personal-future scenarios, the moment's year/month/day must be "
+        "consistent with this date (e.g. \"tomorrow\" is exactly one day "
+        "after it)."
+    )

--- a/app/prompts/timeline.py
+++ b/app/prompts/timeline.py
@@ -7,6 +7,8 @@ Examples:
     >>> prompt = get_prompt("signing of the declaration", "historical")
 """
 
+from app.prompts.temporal_grounding import current_date_grounding
+
 SYSTEM_PROMPT = """You are a historical timeline researcher for TIMEPOINT, an AI system that
 generates immersive visual scenes from temporal moments.
 
@@ -25,6 +27,9 @@ GUIDELINES:
 3. For fictional events, use internal chronology if available
 4. Always provide a location - be as specific as possible
 5. Include brief historical context to aid scene generation
+6. For contemporary and personal_future queries, ground the coordinates against the
+   current real-world date provided in the request — never default to a year from your
+   training data. "Tomorrow" means exactly one day after the provided current date.
 
 EXAMPLES:
 - "signing of the declaration" → July 4, 1776, afternoon, Independence Hall Philadelphia
@@ -34,6 +39,8 @@ EXAMPLES:
 Respond with a JSON object matching the TimelineData schema."""
 
 USER_PROMPT_TEMPLATE = """Extract temporal coordinates for this scene:
+
+{current_date_grounding}
 
 Query: "{query}"
 Query Type: {query_type}
@@ -96,6 +103,7 @@ def get_prompt(
         query=query,
         query_type=query_type,
         context=context,
+        current_date_grounding=current_date_grounding(),
     )
 
 

--- a/tests/unit/test_temporal_grounding.py
+++ b/tests/unit/test_temporal_grounding.py
@@ -1,0 +1,62 @@
+"""Tests for current-date grounding in pipeline prompts.
+
+Tests:
+    - current_date_grounding() embeds the actual current UTC date
+    - judge, timeline, and quick-sim metrics prompts include the grounding block
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.prompts import judge as judge_prompts
+from app.prompts import quick_sim as quick_sim_prompts
+from app.prompts import timeline as timeline_prompts
+from app.prompts.temporal_grounding import current_date_grounding
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+@pytest.mark.fast
+class TestCurrentDateGrounding:
+    """Tests for the shared grounding block builder."""
+
+    def test_contains_current_utc_date(self):
+        assert _today_utc() in current_date_grounding()
+
+    def test_explicit_now_override(self):
+        now = datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc)
+        block = current_date_grounding(now=now)
+        assert "2026-06-09" in block
+        assert "Tuesday" in block
+
+    def test_instructs_relative_resolution(self):
+        block = current_date_grounding()
+        assert "Current real-world date:" in block
+        assert "tomorrow" in block
+
+
+@pytest.mark.fast
+class TestPromptsEmbedGrounding:
+    """Each date-sensitive prompt must embed the grounding block."""
+
+    def test_judge_prompt_grounded(self):
+        prompt = judge_prompts.get_prompt("tomorrow at 10am I meet Maria")
+        assert _today_utc() in prompt
+
+    def test_timeline_prompt_grounded(self):
+        prompt = timeline_prompts.get_prompt(
+            "tomorrow at 10am I meet Maria",
+            query_type="personal_future",
+        )
+        assert _today_utc() in prompt
+
+    def test_quick_sim_metrics_prompt_grounded(self):
+        prompt = quick_sim_prompts.get_metrics_prompt(
+            goal="$50k operating grant",
+            opportunity={"title": "Climate Action Fund", "deadline": "2026-06-12"},
+            scene_context="a tense grant-review meeting",
+        )
+        assert _today_utc() in prompt


### PR DESCRIPTION
Judge and timeline agents fixed temporal coordinates with no notion of the actual current date, so relative prompts (tomorrow, next Tuesday) resolved to training-data 2024. Adds request-time current_date_grounding() injected into judge, timeline (with explicit relative-resolution guideline), and find-money quick-sim metrics prompts. 6 pure prompt-construction tests.