### PR TITLE
fix: ground Find Money quick-sim rationale as factual analysis, not a pitch scene

### DIFF
--- a/app/prompts/quick_sim.py
+++ b/app/prompts/quick_sim.py
@@ -134,8 +134,14 @@ You produce a structured fit assessment with five fields:
   the probability of award (a specific intro to ask for, a tighter framing,
   a complementary co-applicant).
 
-- rationale: One sentence summarizing why these numbers, anchored in the
-  rendered scene.
+- rationale: One or two sentences of factual analysis: why this opportunity
+  does or does not fit the user's goal, and what drives the probability and
+  effort numbers (alignment, eligibility, timing, competition). Write as an
+  analyst's assessment grounded in the goal and the opportunity. Do NOT
+  narrate a live scene or pitch — no present-tense drama ("the user is in a
+  high-stakes pitch", "facing skeptical evaluators", "pitching to the City").
+  The scene below is a visual aid only; assess the opportunity, do not
+  describe the room.
 
 You MUST be honest. The downstream Pro deep-sim is expensive — your job is to
 help the user pick the 5 opportunities most worth that spend. Cluster
@@ -159,8 +165,11 @@ OPPORTUNITY:
 - amount: {amount}
 - deadline: {deadline}
 
-RENDERED FUTURE-MOMENT SCENE (the moment the user is in the midst of pursuing this):
+RENDERED FUTURE-MOMENT SCENE (visual context only — do NOT retell it in your assessment):
 {scene_context}
+
+Assess the opportunity itself. The rationale must read as factual analysis of
+fit and odds, not a narration of the scene above.
 
 Respond with valid JSON matching this schema:
 {{
@@ -170,7 +179,7 @@ Respond with valid JSON matching this schema:
   "effort_estimate": "short phrase with hours",
   "key_risks": ["risk 1", "risk 2", "..."],
   "key_levers": ["lever 1", "lever 2", "..."],
-  "rationale": "one-sentence summary anchored in the scene"
+  "rationale": "factual analysis of fit and odds (no scene narration)"
 }}"""
 
 

--- a/tests/unit/test_api_find_money.py
+++ b/tests/unit/test_api_find_money.py
@@ -37,7 +37,11 @@ from app.api.v1.find_money import (
 )
 from app.config import QualityPreset
 from app.core.pipeline import GenerationPipeline
-from app.prompts.quick_sim import build_future_moment_query
+from app.prompts.quick_sim import (
+    build_future_moment_query,
+    get_metrics_prompt,
+    get_metrics_system_prompt,
+)
 from app.schemas.quick_sim import (
     OpportunityIn,
     QuickSimBatchRequest,
@@ -333,6 +337,64 @@ class TestBuildFutureMomentQuery:
         )
         # Falls back to the "see source for details" sentinel
         assert "see source" in q.lower() or "unspecified" in q.lower()
+
+
+# ---------------------------------------------------------------------------
+# Quick-Sim metrics prompts (rationale framing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+class TestMetricsPromptFraming:
+    """The metrics prompts must steer the rationale toward factual analysis,
+    not a narrated pitch scene. Guards the Find Money "assessment" text from
+    drifting back into present-tense drama (e.g. "in a high-stakes pitch")."""
+
+    def test_system_prompt_forbids_scene_narration(self):
+        # Collapse whitespace so line-wrapped phrases still match.
+        sys = " ".join(get_metrics_system_prompt().lower().split())
+        # Must explicitly tell the model not to narrate a live scene/pitch.
+        assert "do not describe the room" in sys
+        # The drama exemplars we are guarding against are named so the
+        # instruction is model-agnostic (works regardless of model quirks).
+        assert "high-stakes pitch" in sys
+        assert "skeptical evaluators" in sys
+
+    def test_system_prompt_demands_factual_fit_analysis(self):
+        sys = get_metrics_system_prompt().lower()
+        assert "factual analysis" in sys
+        assert "analyst" in sys
+
+    def test_user_prompt_marks_scene_as_visual_context_only(self):
+        prompt = get_metrics_prompt(
+            goal="$50k operating grant by Sept 2026",
+            opportunity={
+                "title": "Climate Action Fund",
+                "summary": "Annual climate grants",
+                "amount": 25000,
+                "deadline": "2026-09-01",
+                "source_url": "https://example.org/x",
+            },
+            scene_context="oak-panelled boardroom, polite tension, slide deck",
+        )
+        low = prompt.lower()
+        # Scene is flagged as context only, and the rationale schema hint must
+        # not ask for scene-anchored narration.
+        assert "visual context only" in low
+        assert "do not retell it" in low
+        assert "no scene narration" in low
+        # Opportunity + goal still flow through for grounding.
+        assert "Climate Action Fund" in prompt
+        assert "$50k operating grant by Sept 2026" in prompt
+
+    def test_rationale_schema_hint_is_not_scene_anchored(self):
+        prompt = get_metrics_prompt(
+            goal="goal",
+            opportunity={"title": "x"},
+            scene_context="a room",
+        )
+        # The old hint ("summary anchored in the scene") is gone.
+        assert "anchored in the scene" not in prompt.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The quick-sim metrics rationale (rendered as the Find Money 'assessment') was instructed to anchor itself in the rendered future-moment scene, producing present-tense pitch narration ('currently in a high-stakes pitch', 'pitching to the City'). Reframes the rationale instruction to factual analyst assessment of fit/odds/effort, marks the scene as visual-context-only, and forbids scene narration — model-agnostic phrasing. Probability/fit/effort/risk calibration untouched. 4 new prompt-construction tests; 78 pass.