### PR TITLE
docs: Flash engine-integration plan (breadth tier of one simulation engine)

### DIFF
--- a/.github/ISSUE_TEMPLATE/flash-execution-pr.md
+++ b/.github/ISSUE_TEMPLATE/flash-execution-pr.md
@@ -1,0 +1,26 @@
+---
+name: Flash execution PR
+about: One actionable item from docs/execution-prs/ (engine-integration plan)
+title: "PR-__: <title>"
+labels: integration-plan
+---
+
+<!-- Paste or summarise the matching docs/execution-prs/PR-__.md spec.
+     Each spec is self-contained: Goal / Scope / Files-grounded-in-real-code /
+     Approach / Acceptance / Test-plan(no-mocks) / Cost-safety / Dependencies. -->
+
+**Spec:** `docs/execution-prs/PR-__.md`
+**Layer-fit:** engine / breadth tier (Flash is the breadth tier of one
+simulation engine with GSS/Pro — see `docs/execution-prs/README.md`).
+**Depends on:**
+**Shared pattern with GSS/Clockchain:**
+
+## Goal
+
+## Acceptance criteria
+
+## Test plan (no mocks)
+
+## Cost / safety
+<!-- comparable-score? fail-closed? grounded? slug-validated? cost-capped?
+     Stability-key-neutral? deploy-private surface? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!-- Flash execution-PR template. See docs/execution-prs/README.md. -->
+
+## What & why
+<!-- Link the PR-*.md spec. One paragraph: what this lands and why now. -->
+
+Implements: `docs/execution-prs/PR-__.md`
+
+## Flash breadth-tier safety checklist
+
+Every quick-sim scoring change obeys the guiding constraints
+(`docs/execution-prs/README.md`). Tick or N/A each:
+
+- [ ] **Comparable, not ad-hoc** — the score means the same on the same scale
+      (anchored to the PR-01 calibration spine); two scores are honestly rankable.
+- [ ] **Fail closed** — a scoring error / ungroundable / low-confidence input
+      excludes or down-ranks with an honest flag; **no fabricated mid-range 0.5**.
+- [ ] **Grounded before scored** — temporal liveness + (where determinable)
+      corroboration/eligibility feed the score; ungroundable → `insufficient_evidence`.
+- [ ] **Slug-validated** — the resolved `depth`/frontier model slug is
+      liveness-checked; a dead slug fails loud, never emits garbage scores.
+- [ ] **Cost-capped** — per-opportunity timeout + batch concurrency + per-opp
+      credit bounds preserved; no unbounded fan-out.
+- [ ] **Charge on success only** — failed opportunities refunded; the
+      `X-Gateway-Metered` contract is respected (no double-charge).
+- [ ] **Stability-key-neutral** — no new inline image render on the quick-sim
+      path; Stability-key isolation preserved.
+- [ ] **Deploy-private noted** — any billing / blob-storage surface that lands
+      in `timepoint-flash-deploy-private-feb-2026` is called out (sync is
+      surgical cherry-pick, not merge).
+- [ ] **Calibration-aware** — if this changes scoring, the impact on the PR-01
+      spine (Brier / Spearman / separability) is stated.
+
+## Tests (no mocks)
+<!-- Per repo policy, only the LLM/provider HTTP boundary may be stubbed.
+     List the tests/unit, tests/integration, tests/e2e you added. -->
+
+- [ ] `pytest tests/unit tests/integration` green
+- [ ] No mocks beyond the LLM/provider HTTP boundary
+
+## Reversibility
+<!-- How to revert. Additive/optional schema fields preferred. -->

--- a/docs/execution-prs/PR-01-quick-sim-calibration-spine.md
+++ b/docs/execution-prs/PR-01-quick-sim-calibration-spine.md
@@ -1,0 +1,121 @@
+# PR-01 — Quick-sim calibration spine (held-out ground truth) — KEYSTONE
+
+**Layer-fit:** engine / breadth tier · **Status: Not Started**
+(**cross-repo** into `timepoint-snag-bench`) · **Depends on:** PR-02 ·
+**Effort:** L · **Cost/risk:** eval LLM-capped, cross-repo, medium.
+
+> **Shared pattern with GSS / Clockchain — this is the SAME spine.** GSS
+> `PR-02` ("Calibration spine, KEYSTONE") elevates SNAG-bench to the held-out,
+> human-labeled ground-truth that every GSS threshold anchors to
+> (Spearman / Brier / separability). Clockchain `PR-02a` requires proposer
+> reputation to *empirically* predict a lower later-challenge rate or the band
+> is wrong. **Flash's quick-sim scores must join the same spine.** Until a
+> Flash `probability_of_award` is calibrated against real outcomes, it is "a
+> guess wearing a number" — and because the web-app surfaces it directly to the
+> user when Pro is skipped (`_quick_sim_derived_results`), it is an
+> *unfalsifiable product claim*. This is the keystone: nothing else in the
+> Flash queue is falsifiable without it.
+
+## Goal
+Stand up a **held-out, outcome-labeled evaluation set** for quick-sim scores
+and wire Flash to it so a `probability_of_award` / `fit_score` / `effort_score`
+can be measured for **calibration** (do predicted probabilities match observed
+frequencies — Brier / reliability curve) and **separability** (do better
+opportunities actually score higher — Spearman / rank correlation against
+labeled outcomes). Replace the latency-only eval (`app/eval/`, whose roadmap
+admits "**Gap: Measures speed only, not quality**") with a quality spine that
+shares SNAG-bench's discipline.
+
+## Scope
+**In:**
+- A held-out **quick-sim eval set**: (goal, opportunity stub, label) triples
+  where the label is a real or expert-judged outcome (won/lost, good-fit/
+  bad-fit, light/heavy effort). Sourced from real Find-Money runs where the
+  outcome is known + a curated seed set. Lives in `timepoint-snag-bench`
+  alongside the existing SNAG harness so the **same eval infra scores both
+  tiers** (Flash breadth + Pro depth) on the same scale.
+- A **calibration scorer**: given Flash's predicted `probability_of_award`
+  across the eval set and the binary outcomes, compute **Brier score** +
+  **reliability curve** (predicted-vs-observed by bucket); given `fit_score` /
+  `effort_score` vs. labels, compute **Spearman rank correlation** +
+  **separability** (does the top-quartile-by-score have a materially higher
+  win rate than the bottom quartile?).
+- A **calibration report** artifact + a CI gate: the spine runs the quick-sim
+  batch endpoint (real Flash, LLM boundary capped) over the eval set and emits
+  the metrics; a regression (Brier worse than baseline, Spearman collapses)
+  **fails loud**.
+- Anchor PR-02's confidence bands to this spine: an `insufficient_evidence`
+  flag should empirically correlate with a worse Brier (the model knows when
+  it doesn't know) — if it doesn't, the band is mis-set.
+
+**Out:**
+- The fail-closed scoring mechanics (**PR-02**, prerequisite).
+- Re-training any model on the eval (that is the LOOP-layer RLSF work, **gated**
+  — same gate as GSS `PR-03`; do not build the training loop here).
+- The Pro-side calibration (lives in GSS `PR-02`; this spec makes Flash a
+  *first-class citizen of the same spine*, not a separate one).
+
+## Files / modules touched
+- **`timepoint-snag-bench` (cross-repo):** add a `quick_sim/` eval set + a
+  calibration scorer module reusing the existing SNAG harness structure (mirror
+  GSS `PR-02`'s cross-repo landing). The Flash batch endpoint
+  (`POST /api/v1/find-money/quick-sim-batch`) is the system-under-test.
+- **`timepoint-flash` (engine):**
+  - `app/eval/runner.py` + `app/eval/schemas.py` — extend beyond latency: add a
+    `quality`/`calibration` eval mode that records predicted scores + (when
+    available) labels, so the spine can read Flash output in a stable shape.
+  - `docs/EVAL_ROADMAP.md` — update the "Gap: speed only" note: the quality gap
+    is now addressed by the calibration spine.
+
+## Approach
+1. **Build the labeled set** (cross-repo, snag-bench): real Find-Money outcomes
+   where known + a curated seed; store (goal, stub, label) with provenance.
+2. **Score calibration, not latency:** Brier + reliability for
+   `probability_of_award`; Spearman + quartile-separability for
+   `fit_score`/`effort_score`. RNG-free, deterministic given the recorded
+   outputs.
+3. **Run real Flash over the set** with the LLM provider boundary capped; record
+   predictions through the extended `app/eval` runner.
+4. **Gate on regression** and **cross-check PR-02's bands:** verify the
+   `insufficient_evidence` flag predicts worse Brier; narrow the band if not
+   (exactly Clockchain `PR-02a`'s "calibrate the band before trusting it").
+5. **One scale for both tiers:** keep the scorer identical to the GSS/Pro side
+   so a Flash score and a Pro score are measured the same way — the
+   precondition for PR-05's calibrated handoff.
+
+## Acceptance criteria
+- A held-out quick-sim eval set with outcome labels + provenance exists in
+  `timepoint-snag-bench`.
+- Running the spine over real Flash output yields a Brier score + reliability
+  curve for `probability_of_award` and a Spearman + quartile-separability
+  number for `fit_score`/`effort_score`.
+- A scoring-quality regression fails the spine loudly (not silently).
+- The PR-02 `insufficient_evidence` flag is shown to predict a worse Brier
+  (else the band is reported as mis-calibrated and narrowed).
+- The scorer is shared with / identical to the GSS/Pro calibration scorer
+  (same scale across breadth + depth tiers).
+
+## Test plan (no mocks)
+- `timepoint-snag-bench` `tests/`: the calibration scorer on a synthetic
+  labeled set with known Brier/Spearman (pure math, asserted to closed form).
+- `timepoint-flash` `tests/integration`: the extended eval runner records
+  predicted scores in the calibration shape over a small real batch (provider
+  HTTP capped); no mocks of the pipeline.
+- End-to-end smoke: run the spine over a tiny labeled fixture and assert the
+  report contains Brier + Spearman + separability.
+
+## Cost / safety
+The eval LLM cost is the quick-sim batch over the eval set — **capped**: small
+held-out set, batch concurrency + per-opp timeout already bound it
+(`find_money.py`), runs in CI/offline not per-user. Stability-key-neutral.
+**Cross-repo:** the snag-bench branch is pushed but the director opens that PR
+manually (`feedback_cross_repo_pr_opening`). No deploy-private surface in Flash;
+the snag-bench harness is its own repo.
+
+## Dependencies / merge order
+**After PR-02** (the spine calibrates an *honest* score; calibrating a
+fabricated 0.5 is meaningless). **The keystone** — PR-05 (calibrated handoff)
+and PR-06 (drift canary) both anchor to the scale this establishes. Joins the
+**same spine** as GSS `PR-02`; coordinate the shared scorer.
+
+## Status: Not Started

--- a/docs/execution-prs/PR-02-fail-closed-confidence-scoring.md
+++ b/docs/execution-prs/PR-02-fail-closed-confidence-scoring.md
@@ -1,0 +1,124 @@
+# PR-02 — Fail-closed quick-sim scoring + per-metric confidence (no fabricated 0.5)
+
+**Layer-fit:** engine / breadth tier · **Status: Not Started** ·
+**Depends on:** none · **Effort:** M · **Cost/risk:** scoring-correctness, low.
+
+> **Shared pattern with GSS / Clockchain:** this is the Flash face of GSS's
+> "score honestly, fail closed" (GSS `PR-01b` removes RNG from scoring and
+> excludes a candidate on a scoring error) and Clockchain's fail-closed
+> promotion (never promote a `challenged` node). A breadth-tier score that
+> can't be computed honestly must **exclude or down-rank with a flag**, never
+> fabricate a mid-range number to fill the selection grid.
+
+## Goal
+Make every `QuickSimMetrics` value either **honestly grounded in the run** or
+**explicitly flagged low-confidence / excluded** — never a fabricated
+mid-range fill. Today the metrics agent
+(`app/agents/quick_sim.py::QuickSimMetricsAgent`) returns a `QuickSimMetrics`
+whose `probability_of_award` / `fit_score` / `effort_score` are taken at face
+value with no confidence signal; on a metrics-agent failure `_simulate_one`
+returns `success=False` (good — that path refunds + flags
+`flash-quick-sim-error`), but there is **no middle path**: a metrics call that
+*succeeds* but had nothing real to anchor on (e.g. an empty/garbage
+`scene_context`, or an opportunity with no summary/amount/deadline) still emits
+three confident-looking 0–1 floats. The prompt *asks* the model to "avoid
+clustering at 0.5" but nothing enforces it.
+
+## Scope
+**In:**
+- Add a **per-metric confidence** field to `QuickSimMetrics`: `score_confidence`
+  (0–1) plus a `confidence_basis` enum (`grounded` / `inferred` /
+  `insufficient_evidence`). The model self-reports it, *and* a deterministic
+  post-check (below) can only **lower** it (fail-closed: the model cannot talk
+  its way up past what the inputs support).
+- **Deterministic confidence floor / cap** in a new pure
+  `app/agents/quick_sim.py` helper (or `app/schemas/quick_sim.py` validator):
+  if the opportunity stub is missing the fields a real assessment needs
+  (no `summary` AND no `amount` AND no `deadline`), or the `scene_context` is
+  the no-op fallback (`"(no scene context available)"` / `"(scene pipeline
+  returned no usable summary)"` — both emitted by
+  `find_money.py::summarize_tdf_for_metrics`), cap `score_confidence` at a low
+  `insufficient_evidence` band and set `confidence_basis=insufficient_evidence`.
+- **Down-rank, don't fabricate:** when `confidence_basis ==
+  insufficient_evidence`, the entry is kept in the batch response (1:1 pairing
+  is preserved) but flagged so the selection page can sort it below grounded
+  entries — never silently mixed in at face value.
+- Surface the new fields through `QuickSimTdfEntry` /
+  `QuickSimBatchResponse` (`app/schemas/quick_sim.py`) so the web-app receives
+  them; they are **additive + optional** so the existing
+  `_seed_quick_sim_tdfs` pairing contract is unbroken.
+- Tighten the prompt (`app/prompts/quick_sim.py::METRICS_SYSTEM_PROMPT`) to
+  require the model to emit `score_confidence` + `confidence_basis` and to
+  explicitly say "if you cannot ground a number, say so — an honest
+  `insufficient_evidence` is worth more than a confident guess."
+
+**Out:**
+- The held-out calibration of *whether* the numbers are right (that is
+  **PR-01**, the spine — this PR makes the score *honest about its own
+  uncertainty*; PR-01 makes it *empirically calibrated*).
+- Grounding the opportunity against the web / Clockchain (**PR-03**).
+- The Flash→Pro contract changes (**PR-05**).
+
+## Files / modules touched
+- `app/schemas/quick_sim.py` — `QuickSimMetrics` (~L129–161): add
+  `score_confidence: float = Field(ge=0, le=1)` and `confidence_basis: str`
+  (enum); `QuickSimTdfEntry` (~L164–211) + `QuickSimBatchResponse`: thread the
+  new fields (optional/defaulted).
+- `app/prompts/quick_sim.py` — `METRICS_SYSTEM_PROMPT` (~L100–149) +
+  `METRICS_USER_TEMPLATE` JSON schema block (~L174–183): add the two fields and
+  the honesty instruction.
+- `app/agents/quick_sim.py` — `QuickSimMetricsAgent.run` (~L100–109): after the
+  LLM call, run the deterministic confidence post-check (pure helper) that can
+  only *lower* `score_confidence`.
+- `app/api/v1/find_money.py` — `_build_tdf_entry` (~L700–741): carry
+  `score_confidence` / `confidence_basis` onto the entry; `_simulate_one`
+  detects the no-op `scene_context` fallback and passes that signal in.
+
+## Approach
+1. **Add the fields, model-reported.** Extend the schema + prompt so the model
+   emits a self-assessed confidence and basis alongside each number.
+2. **Deterministic fail-closed floor.** A pure function inspects the *inputs*
+   (opportunity stub completeness + whether `scene_context` is the no-op
+   fallback) and **caps** confidence + forces `insufficient_evidence` — the
+   model can never report higher confidence than the evidence supports.
+3. **Down-rank, keep the row.** Preserve the 1:1 batch pairing; flag low-conf
+   entries so the web-app sorts them below grounded ones. Never inject a 0.5.
+4. **Additive contract.** New fields default so existing consumers
+   (`_seed_quick_sim_tdfs`) are untouched.
+
+## Acceptance criteria
+- Every `QuickSimMetrics` carries `score_confidence` ∈ [0,1] and a
+  `confidence_basis` ∈ {grounded, inferred, insufficient_evidence}.
+- An opportunity stub with no summary/amount/deadline **and** a no-op
+  `scene_context` produces `confidence_basis == insufficient_evidence` with a
+  capped `score_confidence`, regardless of what the LLM self-reports.
+- No code path emits a hard-coded mid-range fill score; the only ways out are
+  (a) an honest grounded/inferred number with a confidence, or (b) a flagged
+  `insufficient_evidence` row (or the pre-existing `flash-quick-sim-error`).
+- New fields are optional/defaulted; existing `_seed_quick_sim_tdfs` pairing
+  tests stay green.
+
+## Test plan (no mocks)
+- `tests/unit`: the deterministic confidence post-check — a complete stub +
+  rich scene → confidence un-capped; an empty stub + no-op scene_context →
+  `insufficient_evidence` cap (pure, no LLM).
+- `tests/unit`: schema round-trips with the new fields; defaults preserve the
+  old shape (assert a payload without the fields still parses).
+- `tests/integration` (LLM HTTP boundary stubbed at the provider): a batch with
+  one rich and one empty opportunity returns one grounded + one
+  `insufficient_evidence` entry, both present, the empty one flagged.
+- `pytest tests/unit tests/integration` green.
+
+## Cost / safety
+No new LLM calls (confidence is emitted in the same metrics call; the
+post-check is pure). Stability-key-neutral (no image path). Reversible — fields
+are additive; reverting drops them without breaking the pairing contract.
+Lands entirely in the **open-source repo**; no deploy-private surface.
+
+## Dependencies / merge order
+**Root of the Flash spine** — no dependencies; build first. Feeds **PR-01**
+(the spine calibrates the now-honest score), **PR-03** (grounding raises
+confidence from `inferred`→`grounded`), **PR-05** (the handoff carries the
+confidence), **PR-07** (CIs build on the confidence signal).
+
+## Status: Not Started

--- a/docs/execution-prs/PR-03-quick-sim-grounding-pass.md
+++ b/docs/execution-prs/PR-03-quick-sim-grounding-pass.md
@@ -1,0 +1,124 @@
+# PR-03 — Quick-sim grounding pass (opportunity liveness + temporal + Clockchain anchor)
+
+**Layer-fit:** engine / breadth tier ↔ substrate · **Status: Not Started** ·
+**Depends on:** PR-02 · **Effort:** M · **Cost/risk:** web/LLM-capped, medium.
+
+> **Shared pattern with GSS / Clockchain — the grounding bridge.** GSS `PR-01a`
+> anchors M20 grounding to the Clockchain DTI ("verified causal facts → synth
+> knowledge"); this is Spine E (the grounding bridge) of the program map. The
+> Flash breadth tier today **scores entirely ungrounded** — and a
+> `probability_of_award` for an opportunity that has already closed, doesn't
+> exist, or excludes the user is **fabricated confidence** in its purest form.
+> This PR gives quick-sim a cheap, bounded grounding signal before it emits a
+> number, the breadth-tier face of "ground before you score."
+
+## Goal
+Give the quick-sim path a **bounded grounding signal** so the metrics agent
+scores against reality, not just the goal text. Quick-sim deliberately skips
+Grounding + EntityGrounding (`app/core/pipeline.py::run_quick_sim`, L611) for
+latency, and the `GroundingAgent` only fires on `QueryType.HISTORICAL`
+(`app/agents/grounding.py::GroundingInput.needs_grounding`) — but quick-sim
+renders a *future* moment, so grounding **never runs**. The result: scores
+ignore whether the deadline has passed, whether the opportunity is real, or
+whether the user is eligible. The current temporal grounding is only a date
+string injected into the prompt (`app/prompts/temporal_grounding.py::
+current_date_grounding`) — advisory, not enforced.
+
+## Scope
+**In:**
+- A **lightweight, bounded grounding step** for the opportunity stub (not the
+  full scene-grounding fan-out): a single capped check that establishes, where
+  determinable, (a) **temporal liveness** — is the `deadline` in the past
+  relative to `current_date_grounding()`? (deterministic, no LLM); (b)
+  **existence/eligibility signal** — a single bounded grounding call (reusing
+  the `GroundingAgent` machinery / Google-search grounding already in the repo)
+  that returns whether the opportunity is corroborated and any hard
+  eligibility/timing blocker.
+- A **Clockchain anchor (optional, gated-cheap):** when the opportunity names a
+  real organization/program that maps to a Clockchain figure/entity, attach the
+  verified entity context as a grounding fact (Flash already constructs
+  pipelines with `entity_ids` — `find_money.py::_build_generation_pipeline` —
+  and has `app/agents/entity_grounding.py`). This is the Flash side of the
+  GSS↔Clockchain grounding bridge; keep it **read-only** and **fail-open on
+  Clockchain unavailability** (Flash must not hard-depend on the substrate).
+- **Feed the grounding signal into scoring + confidence:** a past deadline is a
+  **hard down-rank** (the prompt already says "a deadline in the past is a hard
+  timing risk" — make it enforced, not advisory); a corroborated + eligible
+  opportunity raises PR-02's `confidence_basis` from `inferred`→`grounded`; an
+  ungroundable one caps it at `insufficient_evidence` (fail-closed).
+- A **hard cost bound:** at most **one** extra grounding call per opportunity,
+  inside the existing per-opp timeout + batch concurrency; the temporal check
+  is free.
+
+**Out:**
+- Re-enabling the full scene Grounding/EntityGrounding fan-out on the quick-sim
+  path (that is the latency sink quick-sim was built to avoid — keep it skipped;
+  this is a *targeted* opportunity-grounding call, not the scene pipeline).
+- Writing anything back to Clockchain (read-only here; the PORTAL→Clockchain
+  contribution loop is GSS-side + gated).
+- The calibration of how much grounding should move the score (**PR-01**
+  measures that).
+
+## Files / modules touched
+- `app/api/v1/find_money.py` — `_simulate_one` (~L534–692): add the bounded
+  opportunity-grounding step (temporal check + one grounding call) before the
+  metrics agent; thread the grounding result into `scene_context` /
+  metrics input and into PR-02's `confidence_basis`.
+- `app/prompts/quick_sim.py` — `METRICS_USER_TEMPLATE` (~L152–183): replace the
+  advisory "judge deadlines against this date" with an enforced
+  grounding-fact block (`OPPORTUNITY GROUNDING: deadline_status=…,
+  corroborated=…, blockers=[…]`); already imports `current_date_grounding`.
+- `app/agents/grounding.py` — reuse `GroundingAgent` for a stub-level
+  corroboration check; if `needs_grounding` gating is in the way, add a narrow
+  `ground_opportunity_stub()` entry that doesn't require `HISTORICAL`.
+- `app/agents/entity_grounding.py` — optional Clockchain entity anchor path
+  (read-only, fail-open).
+
+## Approach
+1. **Free temporal check first.** Parse `deadline` vs. `current_date_grounding()`;
+   a past deadline is a deterministic hard down-rank + risk — no LLM needed.
+2. **One bounded grounding call.** Corroborate existence + surface a hard
+   eligibility/timing blocker; cap to one call inside the per-opp timeout.
+3. **Optional Clockchain anchor.** If the org maps to a verified entity, attach
+   it as a grounding fact (read-only, fail-open — Flash never blocks on the
+   substrate).
+4. **Feed scoring + confidence.** Grounded+eligible → `grounded`; ungroundable
+   → `insufficient_evidence` cap (fail-closed, via PR-02's machinery).
+5. **Stay cheap.** The whole point of quick-sim is breadth; this adds at most
+   one call/opportunity and a free date check.
+
+## Acceptance criteria
+- An opportunity with a past `deadline` is deterministically down-ranked and
+  carries an explicit timing-risk flag (enforced, not just prompt-advisory).
+- A corroborated, eligible opportunity reaches `confidence_basis == grounded`;
+  an uncorroborated one is capped at `insufficient_evidence`.
+- When a named org maps to a Clockchain entity, its verified context appears as
+  a grounding fact; when Clockchain is unavailable, quick-sim still completes
+  (fail-open, no hard dependency).
+- At most one extra grounding LLM call per opportunity; the batch stays inside
+  the existing per-opp timeout + concurrency bounds.
+
+## Test plan (no mocks)
+- `tests/unit`: the deterministic deadline-vs-today check (past/future/absent),
+  pure.
+- `tests/integration` (grounding/LLM HTTP boundary capped, Clockchain hit real
+  or skipped): a stub with a past deadline → down-ranked + flagged; a
+  corroborated stub → `grounded`; an unknown stub → `insufficient_evidence`.
+- `tests/integration`: Clockchain unavailable → quick-sim still returns
+  (fail-open) — assert no exception escapes.
+- `pytest tests/unit tests/integration` green.
+
+## Cost / safety
+One bounded grounding call + a free temporal check per opportunity, inside
+existing cost bounds. **Stability-key-neutral** (text/search grounding only, no
+image). Clockchain read is fail-open. No deploy-private surface. Reversible —
+the grounding step is additive and can be flagged off.
+
+## Dependencies / merge order
+**After PR-02** (grounding moves PR-02's `confidence_basis`). Feeds **PR-01**
+(grounded scores are what the spine should show better-calibrated) and **PR-05**
+(the handoff carries the grounding facts to Pro). The Clockchain-anchor half is
+the Flash node of the program's **Spine E grounding bridge** (mirrors GSS
+`PR-01a`).
+
+## Status: Not Started

--- a/docs/execution-prs/PR-04-model-slug-liveness-guard.md
+++ b/docs/execution-prs/PR-04-model-slug-liveness-guard.md
@@ -1,0 +1,100 @@
+# PR-04 — Model-slug liveness guard (fail loud on dead depth / frontier slugs)
+
+**Layer-fit:** engine / breadth tier (guard rail) · **Status: Not Started** ·
+**Depends on:** none · **Effort:** S · **Cost/risk:** ~1 catalog call/run, low.
+
+> **Shared pattern with GSS — this is the SAME guard.** GSS `PR-00c`
+> ("Model-slug liveness guard") exists because dead OpenRouter slugs silently
+> 404 → empty/garbled sims. The exact failure mode is documented ecosystem-wide
+> in `reference_dead_model_slug_failure_mode.md` (the Pro engine was bitten by
+> a dated `claude-3-5-haiku-…` slug). Flash has the **same exposure**:
+> `VerifiedModels` (`app/config.py` L88–139) is a **static hardcoded list** —
+> `gemini-2.0-flash`, `google/gemini-3-flash-preview`,
+> `anthropic/claude-opus-4.8`, etc. — with **no liveness check**, and the
+> `frontier` depth tier routes to `anthropic/claude-opus-4.8` via OpenRouter.
+> When one of those slugs is silently deprecated, the quick-sim batch returns
+> empty/garbled scores and the user pays for noise.
+
+## Goal
+Validate that the model slug a quick-sim run resolves to is **actually live**
+before the batch runs, and **fail loud** (clear error, refund, flag) rather than
+emitting silent empty/garbled scores. Specifically guard the `depth`-dial
+resolution (`find_money.py::_resolve_quick_sim_text_model` /
+`_DEPTH_TO_TEXT_MODEL`) and the `VerifiedModels` static lists.
+
+## Scope
+**In:**
+- A **liveness check** that confirms a resolved slug exists in the live provider
+  catalog. The repo already has the seam: `app/core/model_registry.py::
+  OpenRouterModelRegistry.is_model_available` (used by
+  `VerifiedModels.is_verified_or_available`, `config.py` L197–206) — extend it
+  so the *static* `VerifiedModels` lists are also liveness-checkable, not just
+  the dynamic-registry path, and cache the catalog (one call/run, not per-opp).
+- Wire the check into the quick-sim model resolution
+  (`_resolve_quick_sim_text_model`): if the resolved slug (default
+  `gemini-2.5-flash`, or a `depth`-dial slug like `gemini-2.0-flash` /
+  `anthropic/claude-opus-4.8`) is **not live**, either (a) fall back to a
+  known-live default with a loud WARNING, or (b) for `frontier`, fail the
+  affected opportunity with an honest error + refund — **never** proceed to emit
+  garbage scores.
+- A startup / CI assertion that every slug in `VerifiedModels.GOOGLE_TEXT`,
+  `OPENROUTER_TEXT`, `_DEPTH_TO_TEXT_MODEL`, and the fallback chains resolves
+  live — so a dead slug is caught in CI, not in production.
+
+**Out:**
+- Image-model slugs / the Stability path (quick-sim doesn't render images
+  inline; out of scope here — but note the same guard should later cover
+  `GOOGLE_IMAGE` / `STABILITY_IMAGE` to protect the Stability-key isolation).
+- Re-architecting the registry (just extend the existing `is_model_available`
+  seam).
+
+## Files / modules touched
+- `app/config.py` — `VerifiedModels` (~L88–208): add a classmethod that
+  liveness-checks the static lists via the model registry; the
+  `is_verified_or_available` seam already exists (L176–208) — generalise it.
+- `app/core/model_registry.py` — `OpenRouterModelRegistry.is_model_available` /
+  catalog cache: ensure a single bounded catalog fetch/run, and a Google-native
+  catalog check for `GOOGLE_TEXT` slugs.
+- `app/api/v1/find_money.py` — `_resolve_quick_sim_text_model` (~L171–190): add
+  the liveness guard with loud-fallback / fail-loud behavior; `_simulate_one`
+  refunds + flags an opportunity whose `frontier` slug is dead.
+- A CI test (`tests/`) asserting all configured slugs resolve live.
+
+## Approach
+1. **One catalog fetch/run, cached.** Liveness is a set-membership check against
+   a cached live catalog — not a per-opportunity call.
+2. **Guard the resolver.** Default/`standard`/`deep`/`fast` → loud fallback to a
+   known-live model; `frontier` → fail the opportunity loud + refund rather than
+   silently degrade a paid frontier request to garbage.
+3. **Catch in CI.** A test enumerates every configured slug and asserts it
+   resolves live — the dead-slug failure mode becomes a red CI, not a silent
+   prod regression (the ecosystem alarm is CI red — `feedback_no_slack`).
+
+## Acceptance criteria
+- A resolved quick-sim slug is liveness-checked before the batch runs (one
+  cached catalog fetch/run, not per-opportunity).
+- A dead default/standard slug → loud WARNING + fallback to a live model; a dead
+  `frontier` slug → that opportunity fails with an honest error + refund, never
+  emits a garbage score.
+- A CI test fails loudly if any slug in `VerifiedModels` /
+  `_DEPTH_TO_TEXT_MODEL` / the fallback chains is dead.
+
+## Test plan (no mocks)
+- `tests/unit`: the liveness classmethod against a real (cached) catalog fixture
+  — a known-live slug passes, a fabricated slug fails.
+- `tests/integration` (provider catalog hit real or capped): `_resolve_quick_sim
+  _text_model` falls back loudly on a dead non-frontier slug; a dead frontier
+  slug yields a failed+refunded opportunity, not a garbage score.
+- `tests/` CI guard: enumerate all configured slugs, assert each resolves live.
+
+## Cost / safety
+One bounded catalog fetch per run (cached), no per-opportunity cost.
+Stability-key-neutral. Pure guard — reversible, additive. Lands in the
+open-source repo; the registry/catalog auth is the same as today.
+
+## Dependencies / merge order
+**Independent — run early.** Guards every later PR (a dead slug poisons the
+calibration spine's inputs too). Mirrors GSS `PR-00c`; the two guards share the
+same failure mode and should stay conceptually identical across the engine.
+
+## Status: Not Started

--- a/docs/execution-prs/PR-05-flash-to-pro-calibrated-handoff.md
+++ b/docs/execution-prs/PR-05-flash-to-pro-calibrated-handoff.md
@@ -1,0 +1,120 @@
+# PR-05 — Flash→Pro calibrated handoff contract (breadth-rank → depth-select)
+
+**Layer-fit:** engine (the breadth↔depth seam) · **Status: Not Started**
+(**cross-repo** — web-app + pro-cloud) · **Depends on:** PR-01, PR-02 ·
+**Effort:** M · **Cost/risk:** cross-repo contract, medium.
+
+> **Shared pattern with GSS / Clockchain — one engine, one scale.** The program
+> map calls Flash the *breadth* tier and GSS/Pro the *depth* tier of **one
+> simulation engine**. Today the seam between them is a lossy raw-float pass:
+> the web-app's deep-sim handoff (`_pro_cloud_create_run` in
+> `timepoint-web-app/app/find_money/runs/jobs.py`) sends Pro Cloud only
+> `tdf_ref` + `tdf` + a `scenario_description` (derived from the quick-sim
+> `rationale`/`summary`) and **drops the Flash scores entirely** — Pro Cloud
+> rebuilds from `strategy_axes`, so a Flash `probability_of_award` and a Pro
+> deep-sim `probability` are **never on the same scale and never reconciled**.
+> Worse, when Pro Cloud is unreachable, the web-app surfaces Flash's raw
+> quick-sim scores **as if they were the deep-sim result**
+> (`_quick_sim_derived_results` → `_seed_deep_sim_results`). The breadth→depth
+> seam must be a **first-class, calibrated contract**, not a silent
+> rescale/relabel.
+
+## Goal
+Define and implement the Flash→Pro handoff as an **explicit, calibrated
+contract**: Flash emits, per opportunity, a *breadth-tier* score with its
+**confidence**, **basis**, and **calibration provenance** (which spine version
+calibrated it — PR-01); Pro consumes it as a *prior* and returns a *depth-tier*
+score **on the same scale** (the shared PR-01 / GSS-`PR-02` scorer), so the two
+are comparable and the user is never shown a breadth score mislabeled as a
+depth score.
+
+## Scope
+**In:**
+- **A typed handoff payload** carried from Flash quick-sim into the deep-sim
+  request. Extend the quick-sim entry (`QuickSimTdfEntry` in
+  `app/schemas/quick_sim.py`) so the web-app can forward — not drop — the
+  Flash score + `score_confidence` + `confidence_basis` (PR-02) + a
+  `calibration_ref` (which PR-01 spine version produced the scale) +
+  grounding facts (PR-03). These are the breadth-tier *prior*.
+- **Pro consumes the prior + returns on the same scale.** The web-app
+  `_pro_cloud_create_run` payload gains the breadth prior alongside each
+  `tdf_ref`; Pro Cloud records it and returns its deep-sim `probability` on the
+  **same calibrated scale** (the shared PR-01/GSS-`PR-02` scorer) so a consumer
+  can honestly say "breadth said 0.4±0.2, depth said 0.55±0.08" — a refinement,
+  not a contradiction-with-no-context.
+- **Honest labeling when Pro is skipped.** When the deep-sim is not run, the
+  result the user sees must be **labeled a breadth-tier estimate with its
+  confidence**, not silently presented as a deep-sim result
+  (fix `_quick_sim_derived_results` / `_seed_deep_sim_results` labeling).
+- **Selection uses the calibrated breadth rank.** The top-N the user shortlists
+  for the expensive Pro spend is ranked on the *calibrated, confidence-aware*
+  Flash score (PR-01 + PR-02 + PR-07), not the raw 0–1 float — spending depth
+  budget on the breadth tier's best-grounded bets.
+
+**Out:**
+- The Pro-side deep-sim scoring internals (GSS queue — this spec defines the
+  *contract* + the scale Pro returns on, not Pro's mechanism math).
+- Re-metering / billing changes (the gateway + `on_behalf_of_user_id` act-as
+  contract is unchanged; do not touch metering).
+- Building the calibration scale itself (**PR-01**, prerequisite).
+
+## Files / modules touched
+- **`timepoint-flash` (engine):** `app/schemas/quick_sim.py` —
+  `QuickSimTdfEntry` (~L164–211): add the typed handoff fields
+  (`score_confidence`, `confidence_basis`, `calibration_ref`,
+  `grounding_facts`) so the breadth prior is *carried*, not dropped (additive /
+  optional — preserves `_seed_quick_sim_tdfs` pairing).
+- **`timepoint-web-app` (cross-repo):** `app/find_money/runs/jobs.py` —
+  `_pro_cloud_create_run` (~L413–490): forward the breadth prior into the
+  `/api/runs` payload instead of discarding it; `_quick_sim_derived_results` /
+  `_seed_deep_sim_results` (~L511+): label the no-deep-sim result as a
+  breadth-tier estimate with confidence.
+- **`timepoint-pro-cloud-private` (cross-repo):** `/api/runs` `TDFSpec` /
+  the run result schema: accept the breadth prior; return the deep-sim
+  `probability` on the shared calibrated scale (coordinate with GSS `PR-02`).
+
+## Approach
+1. **Carry, don't drop.** Flash entry gains the prior fields; the web-app
+   forwards them into the Pro Cloud request.
+2. **One scale.** Pro returns its score on the PR-01/GSS-`PR-02` scale so
+   breadth and depth are directly comparable (refinement, not relabel).
+3. **Label honestly.** No-deep-sim path is explicitly a breadth estimate + its
+   confidence; never masquerades as a deep-sim result.
+4. **Rank on the calibrated score.** Selection orders by the confidence-aware
+   calibrated breadth score so the depth budget goes to the best-grounded bets.
+
+## Acceptance criteria
+- The quick-sim entry carries the breadth prior (`score` + `score_confidence` +
+  `confidence_basis` + `calibration_ref` + `grounding_facts`); existing
+  `_seed_quick_sim_tdfs` pairing is unbroken (additive/optional).
+- The web-app deep-sim request forwards the breadth prior to Pro Cloud instead
+  of dropping it.
+- Pro Cloud returns its deep-sim probability on the **same calibrated scale** as
+  the Flash breadth score (verified via the shared PR-01 scorer).
+- When Pro is skipped, the user-facing result is labeled a breadth-tier estimate
+  with its confidence — never presented as a deep-sim result.
+- Selection ranks on the calibrated, confidence-aware breadth score.
+
+## Test plan (no mocks)
+- `timepoint-flash` `tests/unit`: the entry serialises the prior fields;
+  defaults keep the old pairing shape.
+- `timepoint-web-app` `tests/`: `_pro_cloud_create_run` payload includes the
+  breadth prior; the no-deep-sim path produces a breadth-labeled result (assert
+  the label/flag, not a "placeholder" or a deep-sim claim).
+- Cross-repo integration (Pro Cloud hit real, LLM boundary capped): a handoff
+  round-trips the prior and returns a deep-sim score on the shared scale.
+- `pytest` green in each repo.
+
+## Cost / safety
+No new per-user LLM cost (the prior is data already computed). Stability-key-
+neutral. **Cross-repo:** branches pushed in web-app + pro-cloud; the director
+opens those PRs manually (`feedback_cross_repo_pr_opening`). pro-cloud vendors
+pro-internal via subtree — coordinate the scale change with GSS `PR-02`. No
+Flash deploy-private surface (the Flash change is open-source-repo schema).
+
+## Dependencies / merge order
+**After PR-01** (the shared scale must exist) **and PR-02** (the confidence the
+prior carries). The breadth↔depth seam of **one engine** — coordinate with GSS
+`PR-02` so both tiers report on the identical scale.
+
+## Status: Not Started

--- a/docs/execution-prs/PR-06-quick-sim-observability.md
+++ b/docs/execution-prs/PR-06-quick-sim-observability.md
@@ -1,0 +1,94 @@
+# PR-06 — Quick-sim observability: score flight-recorder + calibration-drift canary
+
+**Layer-fit:** engine / breadth tier (cross-cutting) · **Status: Not Started** ·
+**Depends on:** PR-01 · **Effort:** M · **Cost/risk:** observability only, low.
+
+> **Shared pattern with GSS / Clockchain.** GSS `PR-XX-obs` adds full mechanism
+> tracking + a run flight-recorder; Clockchain `PR-XX` adds a data canary. The
+> Flash face is a **score flight-recorder + calibration-drift canary**: a
+> calibrated breadth-tier score (PR-01) is only trustworthy if you can *see* it
+> drift. This guards every later run the same way the GSS/Clockchain canaries do
+> — and the ecosystem alarm is **CI/canary red, not Slack** (`feedback_no_slack`).
+
+## Goal
+Record, per quick-sim run, the inputs and outputs needed to (a) reproduce a
+score and (b) detect **calibration drift** over time, and stand up a canary that
+fails loud when the live score distribution diverges from the PR-01 spine's
+calibrated baseline — e.g. probabilities start clustering at 0.5 again, the
+`insufficient_evidence` rate spikes (grounding broke), or a slug silently
+degraded (catches the PR-04 failure mode in production).
+
+## Scope
+**In:**
+- A **score flight-recorder**: structured log/record per opportunity capturing
+  goal, opportunity stub digest, resolved `depth`/model slug, the five metrics +
+  `score_confidence` + `confidence_basis` (PR-02), grounding result (PR-03),
+  `calibration_ref` (PR-01), and latency. Enough to reproduce + audit a score.
+  Flash already logs richly in `find_money.py` (`logger.info` per opportunity);
+  this is a structured, queryable record, not free-text.
+- A **calibration-drift canary** (cross-repo ops, mirrors the ecosystem
+  cron/canary pattern): periodically score a small fixed probe set through the
+  live quick-sim endpoint and compare the distribution + Brier against the PR-01
+  baseline; **fail loud** (red CI/cron) on drift — clustering, confidence
+  collapse, or a Brier regression.
+- Surface aggregate health (score distribution, `insufficient_evidence` rate,
+  mean confidence) read-only, so a human can see the breadth tier's honesty at
+  a glance.
+
+**Out:**
+- Re-training / auto-correction (LOOP-layer RLSF, **gated** — same gate as GSS
+  `PR-03`).
+- Per-user PII in the recorder (record a stub *digest*, respect key-hygiene).
+- The calibration math itself (**PR-01**).
+
+## Files / modules touched
+- `app/api/v1/find_money.py` — `_simulate_one` / `_build_tdf_entry`
+  (~L534–741): emit the structured score record alongside the existing
+  `logger.info` calls.
+- `app/eval/runner.py` — reuse the PR-01 calibration scorer for the canary's
+  baseline comparison (the canary is the spine run on a fixed probe set on a
+  schedule).
+- **Cross-repo ops** (`timepoint-dev-management` cron / canary infra, mirrors
+  `uptime-monitor.py` / `db-health-check.py`): a scheduled quick-sim calibration
+  probe that fails loud on drift.
+
+## Approach
+1. **Record what reproduces a score.** Structured per-opportunity record
+   (inputs digest + outputs + confidence + grounding + slug + calibration_ref).
+2. **Probe + compare on a schedule.** Run a fixed probe set through the live
+   endpoint; compare distribution + Brier to the PR-01 baseline.
+3. **Fail loud.** Drift → red canary (the alarm), never a silent degrade —
+   catches re-clustering, confidence collapse, broken grounding, and dead slugs
+   in production.
+
+## Acceptance criteria
+- Every quick-sim opportunity emits a structured, reproducible score record
+  (no raw PII — stub digest only).
+- A scheduled canary scores a fixed probe set and compares to the PR-01
+  baseline; a drift (clustering, `insufficient_evidence` spike, Brier
+  regression) fails the canary loud.
+- Aggregate breadth-tier health (distribution, conf, insufficient rate) is
+  readable.
+
+## Test plan (no mocks)
+- `tests/unit`: the score-record builder produces the full reproducible record
+  from a `_simulate_one` result; asserts no raw PII (digest only).
+- `tests/integration`: a probe batch run through the real endpoint (LLM
+  boundary capped) yields records the canary can score against the PR-01
+  baseline; an injected clustering distribution trips the drift check.
+- Canary cron tested against a fixture baseline (drift vs. no-drift cases).
+
+## Cost / safety
+Recorder is logging-only (no LLM). The canary cost is one small probe batch on a
+schedule — capped, off the user path. Stability-key-neutral. Respects
+key-hygiene (digest, no PII). No deploy-private surface in Flash; the canary is
+ops cron in dev-management. Reversible.
+
+## Dependencies / merge order
+**After PR-01** (the canary needs the calibrated baseline to drift *from*).
+Cross-cutting — guards PR-03 (grounding break shows as confidence collapse),
+PR-04 (a dead slug shows as a distribution shift), and PR-05 (a handoff scale
+regression shows as Brier drift). Mirrors GSS `PR-XX-obs` + Clockchain
+`PR-XX-data-canary`.
+
+## Status: Not Started

--- a/docs/execution-prs/PR-07-rank-stability-ci.md
+++ b/docs/execution-prs/PR-07-rank-stability-ci.md
@@ -1,0 +1,83 @@
+# PR-07 — Rank-stability + ties: surface CIs so a "tied" shortlist reads as tied
+
+**Layer-fit:** engine / breadth tier · **Status: Not Started** ·
+**Depends on:** PR-02 · **Effort:** S · **Cost/risk:** scoring-presentation, low.
+
+> **Shared pattern with GSS.** GSS `PR-01b` attaches a **confidence interval**
+> to every `outcome_score` (`outcome_score_low`/`outcome_score_high`) "so
+> consumers see when two leads are statistically tied." The Flash breadth tier
+> ranks up to 15 opportunities and the user shortlists the top-N for expensive
+> Pro deep-sim — if opportunities #5 and #6 are statistically indistinguishable,
+> presenting a hard rank that puts #6 below the cut is **fabricated precision**.
+> Same idea, breadth-tier face: a tie must read as a tie.
+
+## Goal
+Surface a confidence band on each quick-sim score so the selection page can show
+when two opportunities are **statistically tied** rather than implying a false
+ordering, and so the breadth→depth handoff (PR-05) carries the band. Builds
+directly on PR-02's `score_confidence` (the band width follows from the
+confidence + basis).
+
+## Scope
+**In:**
+- Derive a **confidence band** per scored metric from PR-02's `score_confidence`
+  + `confidence_basis`: a low-confidence / `inferred` score gets a wide band, a
+  `grounded` high-confidence score a narrow one. Deterministic mapping (no RNG),
+  or — where the `depth` tier runs multiple samples — a real spread.
+- Add `probability_low`/`probability_high` (and the same for `fit_score`) to
+  `QuickSimMetrics` / `QuickSimTdfEntry` (`app/schemas/quick_sim.py`), additive
+  + optional (preserves the `_seed_quick_sim_tdfs` pairing).
+- A **tie helper** (pure): two opportunities whose bands overlap beyond a
+  threshold are flagged `rank_tied` so the web-app can present them as a tied
+  cluster rather than a hard 1-2-3 order.
+
+**Out:**
+- The held-out calibration of the band widths (**PR-01** measures whether a
+  "narrow" band is actually narrow); this PR *surfaces* uncertainty, PR-01
+  *validates* it.
+- Web-app rendering of the tie cluster (web-app's job; this PR provides the
+  `rank_tied` signal).
+
+## Files / modules touched
+- `app/schemas/quick_sim.py` — `QuickSimMetrics` (~L129–161) +
+  `QuickSimTdfEntry` (~L164–211): add `probability_low/high`, `fit_score_low/high`
+  (optional/defaulted); a `rank_tied` flag on the entry.
+- `app/agents/quick_sim.py` or a new pure helper: confidence → band mapping.
+- `app/api/v1/find_money.py` — `_run_batch` / `_build_tdf_entry`
+  (~L817–741): compute `rank_tied` across the batch's entries (pure, after all
+  settle) so overlapping bands are flagged.
+
+## Approach
+1. **Band from confidence.** Map PR-02's `score_confidence`/`confidence_basis`
+   to a deterministic band width (wider for `inferred`/low-conf).
+2. **Flag ties.** A pure cross-batch pass marks entries whose bands overlap
+   beyond threshold as `rank_tied`.
+3. **Carry it.** The band + tie flag ride on the entry into PR-05's handoff and
+   PR-06's recorder.
+
+## Acceptance criteria
+- Each scored metric carries a `_low`/`_high` band; a `grounded` high-confidence
+  score has a narrower band than an `inferred` low-confidence one.
+- Two opportunities with overlapping bands are flagged `rank_tied`; clearly
+  separated ones are not.
+- Fields are additive/optional; `_seed_quick_sim_tdfs` pairing tests stay green.
+- No RNG in the band derivation (deterministic from confidence).
+
+## Test plan (no mocks)
+- `tests/unit`: confidence→band mapping (high-conf narrow, low-conf wide), pure.
+- `tests/unit`: the tie helper — overlapping bands → `rank_tied`, separated → not.
+- `tests/integration` (LLM boundary capped): a batch with two near-identical
+  opportunities returns them `rank_tied`; a clearly-better one is not tied with
+  a clearly-worse one.
+- `pytest tests/unit tests/integration` green.
+
+## Cost / safety
+No new LLM cost (band derives from existing confidence; the helper is pure).
+Stability-key-neutral. Additive/reversible. Open-source repo only.
+
+## Dependencies / merge order
+**After PR-02** (the band derives from PR-02's confidence). Feeds **PR-05** (the
+handoff carries the band + tie flag) and **PR-06** (the recorder logs it).
+Mirrors GSS `PR-01b`'s CI work.
+
+## Status: Not Started

--- a/docs/execution-prs/README.md
+++ b/docs/execution-prs/README.md
@@ -1,0 +1,202 @@
+# Flash — Engine-Integration Execution PR Tracker
+
+This directory positions **Timepoint Flash** inside the unified
+**grounded world-model loop** (mapped in
+`timepoint-dev-management/docs/TIMEPOINT_PROGRAM.md`,
+branch `docs-timepoint-program-jun13`) and turns that positioning into
+**ready-to-implement PR specs**. Each `PR-*.md` is a self-contained brief an
+agent can pick up and execute without re-deriving the design.
+
+These are **specs, not code.** Nothing here implements a feature or deploys.
+Already-shipped work is documented at its *real* status, not re-specced.
+
+> This tracker **mirrors exactly** the house style established by the GSS
+> queue (`timepoint-pro-internal/docs/execution-prs/`) and the Clockchain
+> queue (`timepoint-clockchain/docs/execution-prs/`): index README with
+> guiding constraints + PR-index table + merge-order DAG, one self-contained
+> `PR-*.md` spec per work item, plus `.github` PR + issue templates. The same
+> format lets a team of agents iterate over **all three engine/substrate
+> queues** identically.
+
+## Where Flash sits in the architecture
+
+The program is one loop: **SUBSTRATE** (Clockchain causal graph + entity
+registry) → **ENGINE** (simulation) → **LOOP** (TDF export → SNAG-bench →
+gated training) → **PRODUCT** (web-app + skipmeetings).
+
+**Flash is the breadth tier of the ENGINE layer.** GSS / Timepoint Pro is the
+depth tier (deep-sim + PORTAL abduction). They are **not two engines** — they
+are the two halves of **one simulation engine**:
+
+- **Flash = quick-sim / breadth.** Given a goal and 1–15 opportunity stubs, it
+  renders a fast future-moment TDF per opportunity (the LIGHT pipeline path:
+  Judge → Timeline → Scene → CharacterID → Moment, five LLM calls —
+  `app/core/pipeline.py::run_quick_sim`) and extracts five structured fit
+  metrics (`probability_of_award`, `fit_score`, `effort_score`, risks, levers
+  — `app/agents/quick_sim.py`, `app/schemas/quick_sim.py`). It is the
+  **first-pass ranker** in the Find-Money pipeline: web-search sourcing →
+  **Flash quick-sim batch** → user selects top-N → Pro deep-sim (optional) →
+  result.
+- **GSS/Pro = deep-sim / depth.** It re-simulates the selected opportunities
+  with the 21-mechanism engine, forward/branching/abductive.
+
+**The breadth tier's job is to spend the depth tier's budget wisely.** A
+Flash quick-sim score that is not comparable, not calibrated, and not grounded
+sends the user's expensive Pro deep-sim spend at noise — and, when the user
+skips Pro, **Flash's `probability_of_award` is surfaced to the user as the
+final answer** (web-app `_quick_sim_derived_results` in
+`app/find_money/runs/jobs.py`). So Flash scores are *product output*, not just
+an internal pre-filter.
+
+### The one discipline (shared across every queue)
+
+**Grounded confidence over fabricated confidence.** No number is trusted until
+it has been calibrated against ground truth or corroborated. Fail closed.
+Score honestly. Reversible + audited. Hard cost bounds. Respect the synths.
+
+Today, Flash's scoring discipline is **prompt-only**. The metrics system prompt
+(`app/prompts/quick_sim.py::METRICS_SYSTEM_PROMPT`) *asks* the model to "anchor
+against base rates", "avoid clustering at 0.5", and "calibrate" — but there is:
+
+- **no held-out ground truth** (the only eval, `app/eval/`, measures *latency*,
+  not accuracy — `docs/EVAL_ROADMAP.md` says so explicitly: "**Gap: Measures
+  speed only, not quality**");
+- **no comparability guarantee** between two Flash scores or between a Flash
+  score and a Pro score (the Flash→Pro handoff carries raw 0–1 floats with no
+  shared scale — web-app `jobs.py`);
+- **no grounding** on the quick-sim path at all (`run_quick_sim` *deliberately
+  skips* Grounding + EntityGrounding — `pipeline.py` L611 — and the
+  `GroundingAgent` only fires on `QueryType.HISTORICAL`, while quick-sim renders
+  a *future* moment, so it would never fire anyway);
+- **no fail-closed scoring** — a metrics-agent value is taken at face value;
+  there is no exclusion-on-low-confidence path, and `np`-style RNG is absent
+  but the temperature-0.3 LLM is the only thing standing between two
+  opportunities and an identical 0.5.
+
+This is the **same pathology** the GSS Math-Integrity review found ("uncalibrated
+thresholds, no ground-truth calibration wired up, no score is falsifiable") —
+in a different repo. The integration plan below aligns Flash's quick-sim
+scoring to the **same calibration spine + fail-closed + grounded-confidence
+discipline** as GSS/Clockchain, and defines the **Flash→Pro handoff as a
+first-class, calibrated contract**.
+
+## Vendored deploy / Stability realities (do not break these)
+
+- **Open-source upstream + private deploy fork.** This repo is the *upstream
+  reference implementation* (ships `NoOpBilling` + `local` blob backend). The
+  live `flash.timepointai.com` service runs from the **private fork**
+  `timepoint-flash-deploy-private-feb-2026`, which adds billing, R2 blob
+  storage, and request-signing (`docs/DEPLOY.md`, `docs/STORAGE.md`). Every
+  spec here is authored against the **open-source paths**; anything touching
+  billing or blob storage must call out the deploy-private surface it lands in.
+  Per `feedback_deploy_private_sync`, deploy-private sync is **surgical
+  `git cherry-pick`, not merge**.
+- **Auth is stripped here, owned by the gateway.** `AUTH_ENABLED=false`
+  (`app/config.py` L514); Flash sits behind `timepoint-api-gateway`, which owns
+  user auth + credits and sets `X-Gateway-Metered` to prevent double-charging
+  (`find_money.py::_maybe_spend_credits`). Specs must respect the gateway
+  metering contract — never re-introduce a charge the gateway already metered.
+- **Stability key isolation.** Flash is the **only** service that holds a
+  Stability image key (`VerifiedModels.STABILITY_IMAGE`); Clockchain's image
+  renders were a documented drain on it and were isolated/turned off
+  (`reference_stability_key_routing.md`). The quick-sim path **does not render
+  images** inline (`generate_image` is ignored; images are a fire-and-forget
+  background task — `find_money.py::_schedule_quick_sim_image_gen`), so the
+  scoring work here is **Stability-key-neutral**. Any spec that touches image
+  cost must preserve that isolation.
+
+## The guiding constraints (every PR obeys these)
+
+Learned, non-negotiable (mirrors the GSS/Clockchain constraints, specialised to
+the breadth tier):
+
+- **A quick-sim score must be comparable, not ad-hoc.** Two Flash scores —
+  and a Flash score vs. a Pro score — must mean the same thing on the same
+  scale, or the ranking is noise and the handoff lies. Calibration before
+  trust. *(Shared pattern with GSS `PR-02` calibration spine + Clockchain
+  proposer-reputation calibration.)*
+- **Ground before you score.** A `probability_of_award` for an opportunity
+  whose deadline has passed, whose eligibility excludes the user, or that
+  doesn't exist, is fabricated confidence. Quick-sim must have *some* grounding
+  signal — at minimum a cheap, bounded liveness/temporal check — before it
+  emits a number. *(Shared pattern with GSS `PR-01a` Clockchain-DTI anchor +
+  Clockchain corroboration.)*
+- **Fail closed.** A metrics-agent error, an ungroundable opportunity, or a
+  low-confidence read must **exclude or down-rank with an honest flag** — never
+  fabricate a mid-range 0.5 to fill the grid. *(Shared with GSS "score
+  honestly, fail closed".)*
+- **Pin and guard model slugs.** `VerifiedModels` is a **static hardcoded
+  list** (`config.py` L88–139, incl. `anthropic/claude-opus-4.8` for the
+  `frontier` depth tier) with **no liveness check** — a silently-deprecated
+  OpenRouter slug 404s and the batch returns empty/garbled scores. The resolver
+  must validate the resolved slug is live and **fail loud**. *(Shared pattern
+  with GSS `PR-00c` slug-liveness guard — this is the **same guard**, same
+  failure mode, documented in `reference_dead_model_slug_failure_mode.md`.)*
+- **Hard cost bounds, always.** Quick-sim batches up to 15 opportunities × the
+  five-call light path × a per-opportunity credit; the batch must stay cheap
+  enough that users run discovery before paying for Pro. Concurrency + per-opp
+  timeout + per-opp credit are bounded today (`find_money.py`); keep them so.
+  *(Shared with GSS `budget_limit_usd` / `HARD_CONSTRAINT`.)*
+- **Charge on success only.** Already honored — failed opportunities are
+  refunded (`find_money.py::_refund_credits`); the gateway-metered header
+  short-circuits per-opp charges. Mirrors GSS `PR-00d` charge-on-success.
+
+## PR index
+
+Status legend: `Not Started` · `In Progress` · `In Review` · `Done` ·
+`Gated` (do not build yet).
+
+| ID | Title | Layer-fit | Status | Depends on | Effort | Cost / risk |
+|----|-------|-----------|--------|------------|--------|-------------|
+| [PR-01](PR-01-quick-sim-calibration-spine.md) | **Quick-sim calibration spine (held-out ground truth, KEYSTONE)** | engine/breadth | Not Started (**cross-repo** `timepoint-snag-bench`) | PR-02 | L | eval LLM-capped, **cross-repo**, medium |
+| [PR-02](PR-02-fail-closed-confidence-scoring.md) | Fail-closed scoring + per-metric confidence (no fabricated 0.5) | engine/breadth | Not Started | none | M | scoring-correctness, low |
+| [PR-03](PR-03-quick-sim-grounding-pass.md) | Quick-sim grounding pass (opportunity liveness + temporal + Clockchain anchor) | engine/breadth ↔ substrate | Not Started | PR-02 | M | web/LLM-capped, medium |
+| [PR-04](PR-04-model-slug-liveness-guard.md) | Model-slug liveness guard (fail loud on dead `depth`/frontier slugs) | engine/breadth (guard) | Not Started | none | S | 1 catalog call/run, low |
+| [PR-05](PR-05-flash-to-pro-calibrated-handoff.md) | **Flash→Pro calibrated handoff contract (breadth-rank → depth-select)** | engine (breadth↔depth seam) | Not Started | PR-01, PR-02 | M | cross-repo contract (web-app + pro-cloud), medium |
+| [PR-06](PR-06-quick-sim-observability.md) | Quick-sim observability — score flight-recorder + calibration drift canary | engine/breadth (cross-cutting) | Not Started | PR-01 | M | observability only, low |
+| [PR-07](PR-07-rank-stability-ci.md) | Rank-stability + ties: surface CIs so a "tied" shortlist reads as tied | engine/breadth | Not Started | PR-02 | S | scoring-presentation, low |
+
+> No padding: every spec above is grounded in a real defect or a real seam read
+> in this repo (cited per-spec). The calibration-spine work (`PR-01`) is
+> **cross-repo** into `timepoint-snag-bench` — per `feedback_cross_repo_pr_opening`
+> the branch is pushed there but the director opens that PR manually.
+
+## Recommended merge order
+
+**Calibration-spine-first**, mirroring the GSS DAG. The spine (`PR-01`) is the
+keystone everything anchors to; `PR-02` makes the score honest first so the
+spine has something falsifiable to measure.
+
+```
+PR-02 (fail-closed scoring + per-metric confidence) ──┬─> PR-01 (CALIBRATION SPINE / KEYSTONE) ──┬─> PR-05 (Flash→Pro calibrated handoff)
+       │                                              │                                          └─> PR-06 (score flight-recorder + drift canary)
+       ├─> PR-03 (grounding pass: liveness + temporal + Clockchain anchor)
+       └─> PR-07 (rank-stability CIs)
+
+PR-04 (model-slug liveness guard)   (independent, early — guards every later PR)
+```
+
+Practical sequence: **PR-02 (make the score honest + fail-closed) → PR-01
+(stand up the held-out calibration spine) → PR-03 (ground it) + PR-07 (ties) →
+PR-05 (calibrated handoff to Pro) → PR-06 (observe drift)**, with **PR-04** run
+early as the guard. **PR-02 makes the score honest; PR-01 makes it falsifiable
+and comparable; PR-03 grounds it; PR-05 makes the breadth→depth seam a real
+contract instead of a raw float; PR-06 keeps it honest over time.**
+
+## How to use these specs
+
+1. Pick the lowest-numbered `Not Started` PR whose dependencies are `Done`.
+2. Read its spec end-to-end. **Files/modules to touch** and **Approach** are
+   grounded in the current codebase (real paths in `timepoint-flash` and, where
+   marked, `timepoint-snag-bench` / `timepoint-web-app` / `timepoint-flash-
+   deploy-private-feb-2026`).
+3. Branch with a distinctive scope-bearing name (never reuse a branch name —
+   `feedback_branch_naming`). Implement against the **Acceptance criteria**.
+4. Write tests per the **Test plan** — **no mocks** (`feedback_no_mocks`): the
+   repo has `pytest` (`tests/unit`, `tests/integration`, `tests/e2e`). The
+   **only** stubbable boundary is the LLM/provider HTTP call; every other path
+   runs for real.
+5. Open the PR with `.github/pull_request_template.md`; complete the Flash
+   safety checklist (comparable-score? fail-closed? grounded? slug-validated?
+   cost-capped? Stability-key-neutral? deploy-private surface noted?).
+6. Flip this table's `Status` and the spec's `Status:` line when state changes.


### PR DESCRIPTION
Positions **Timepoint Flash** explicitly as the **breadth (quick-sim) tier** of the **one simulation engine** it forms with GSS/Timepoint Pro (the depth tier), inside the unified grounded-world-model loop (`timepoint-dev-management/docs/TIMEPOINT_PROGRAM.md`). Docs only — no engine code, no deploy, no merge of behavior.

## The finding (grounded in real code)
Flash's quick-sim scoring discipline is **prompt-only**. `app/prompts/quick_sim.py::METRICS_SYSTEM_PROMPT` *asks* the model to "anchor against base rates / avoid clustering at 0.5 / calibrate", but:
- **No held-out ground truth** — `app/eval/` measures *latency* only; `docs/EVAL_ROADMAP.md` literally says "Gap: Measures speed only, not quality".
- **No grounding on the quick-sim path** — `app/core/pipeline.py::run_quick_sim` deliberately skips Grounding + EntityGrounding (L611), and `GroundingAgent` only fires on `QueryType.HISTORICAL` while quick-sim renders a *future* moment, so it never grounds at all.
- **No fail-closed scoring** — a metrics-agent value is taken at face value; nothing prevents a fabricated mid-range fill.
- **No comparability** — the Flash→Pro handoff (`timepoint-web-app/app/find_money/runs/jobs.py::_pro_cloud_create_run`) sends Pro Cloud only `tdf_ref`+`tdf`+`scenario_description` and **drops the Flash scores**; Pro rebuilds from `strategy_axes`, so breadth and depth scores are never on the same scale. When Pro is unreachable, the web-app surfaces Flash's raw quick-sim score **as the final answer** (`_quick_sim_derived_results`) — so an uncalibrated breadth score is *product output*, not just a pre-filter.
- **No slug-liveness guard** — `app/config.py::VerifiedModels` is a static hardcoded list (incl. `anthropic/claude-opus-4.8` for the `frontier` depth dial) with no liveness check; a silently-deprecated slug 404s into empty/garbled scores (the ecosystem dead-slug failure mode).

This is the **same pathology** the GSS Math-Integrity review found ("no ground-truth calibration wired up, no score is falsifiable"), in a different repo.

## The plan — `docs/execution-prs/`
Align Flash's quick-sim scoring to the **same calibration spine + fail-closed + grounded-confidence discipline** as GSS/Clockchain, and make the **Flash→Pro breadth→depth handoff a first-class, calibrated contract**.

Merge order (calibration-spine-first, mirroring the GSS DAG):
- **PR-02** — fail-closed scoring + per-metric confidence (no fabricated 0.5) *(root)*
- **PR-01** — quick-sim calibration spine, held-out ground truth, **KEYSTONE** *(cross-repo → `timepoint-snag-bench`)*
- **PR-03** — quick-sim grounding pass (opportunity liveness + temporal + Clockchain anchor; the Spine-E grounding bridge)
- **PR-04** — model-slug liveness guard (fail loud; mirrors GSS PR-00c) *(independent, early)*
- **PR-05** — **Flash→Pro calibrated handoff contract** (breadth-rank → depth-select; one scale) *(cross-repo → web-app + pro-cloud)*
- **PR-06** — score flight-recorder + calibration-drift canary (mirrors GSS PR-XX-obs / Clockchain data-canary)
- **PR-07** — rank-stability CIs so a tied shortlist reads as tied (mirrors GSS PR-01b CIs)

Every spec is grounded in real paths/functions cited in-spec and carries a "Shared pattern with GSS/Clockchain" cross-reference. Notes the vendored deploy-private (`timepoint-flash-deploy-private-feb-2026`, surgical cherry-pick sync), gateway-owned auth (`AUTH_ENABLED=false` + `X-Gateway-Metered`), and Stability-key-isolation realities (quick-sim is Stability-key-neutral).

Also adds `.github` PR + issue templates (Flash breadth-tier safety checklist).

The keystone (PR-01) and the RLSF training loop stay aligned with the program gates: **build PR-02 then PR-01 first; the LOOP-layer training loop is gated** (same gate as GSS PR-03).