### PR TITLE
feat: fail-closed quick-sim scoring with per-metric confidence

### DIFF
--- a/app/agents/quick_sim.py
+++ b/app/agents/quick_sim.py
@@ -30,7 +30,7 @@ from typing import Any
 from app.agents.base import AgentResult, BaseAgent
 from app.core.llm_router import LLMRouter
 from app.prompts import quick_sim as quick_sim_prompts
-from app.schemas.quick_sim import QuickSimMetrics
+from app.schemas.quick_sim import QuickSimMetrics, apply_confidence_floor
 
 # Quick-sim runs the metrics call at a low, fixed sampling temperature so
 # calibration stays stable across a batch.
@@ -100,10 +100,26 @@ class QuickSimMetricsAgent(BaseAgent[QuickSimMetricsInput, QuickSimMetrics]):
     async def run(self, input_data: QuickSimMetricsInput) -> AgentResult[QuickSimMetrics]:
         """Execute the metrics agent.
 
+        After the LLM call, runs the deterministic fail-closed post-check
+        (:func:`app.schemas.quick_sim.apply_confidence_floor`) against the
+        *inputs* — it can only ever *lower* ``score_confidence`` / force an
+        ``insufficient_evidence`` basis, never raise it. This is what keeps
+        a no-signal call (empty opportunity stub + no-op scene_context) from
+        emitting confident-looking 0–1 floats; it abstains/flags instead.
+
         Args:
             input_data: Goal + opportunity + scene context bundle.
 
         Returns:
             AgentResult with QuickSimMetrics on success, error otherwise.
         """
-        return await self._call_llm(input_data, temperature=_METRICS_TEMPERATURE)
+        result = await self._call_llm(input_data, temperature=_METRICS_TEMPERATURE)
+        if result.success and result.content is not None:
+            adjusted = apply_confidence_floor(
+                result.content,
+                opportunity=input_data.opportunity,
+                scene_context=input_data.scene_context,
+            )
+            if adjusted is not result.content:
+                result.content = adjusted
+        return result

--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -732,6 +732,8 @@ def _build_tdf_entry(
         probability=metrics.probability_of_award if metrics is not None else None,
         fit_score=metrics.fit_score if metrics is not None else None,
         effort_score=metrics.effort_score if metrics is not None else None,
+        score_confidence=metrics.score_confidence if metrics is not None else None,
+        confidence_basis=metrics.confidence_basis if metrics is not None else None,
         amount_usd=opportunity.amount,
         source="flash-quick-sim" if success else "flash-quick-sim-error",
         tdf=result.get("tdf"),

--- a/app/prompts/quick_sim.py
+++ b/app/prompts/quick_sim.py
@@ -134,6 +134,19 @@ You produce a structured fit assessment with five fields:
   the probability of award (a specific intro to ask for, a tighter framing,
   a complementary co-applicant).
 
+- score_confidence (0.0-1.0): How much the three scores above can be trusted,
+  given what you actually had to read. High (0.7+) only when the opportunity
+  has real detail (summary, amount, deadline) AND the scene grounds it. Low
+  (below 0.3) when the opportunity is a bare title with no amount/deadline, or
+  the scene context is empty/placeholder. If you cannot ground a number, SAY SO
+  — an honest low-confidence "insufficient_evidence" is worth more to the user
+  than a confident guess. Do NOT report high confidence to fill the grid.
+
+- confidence_basis: One of exactly "grounded", "inferred", or
+  "insufficient_evidence". Use "grounded" only when real opportunity facts and
+  a usable scene back the numbers; "inferred" when you reasoned from partial
+  signal; "insufficient_evidence" when there was nothing real to anchor on.
+
 - rationale: One or two sentences of factual analysis: why this opportunity
   does or does not fit the user's goal, and what drives the probability and
   effort numbers (alignment, eligibility, timing, competition). Write as an
@@ -179,7 +192,9 @@ Respond with valid JSON matching this schema:
   "effort_estimate": "short phrase with hours",
   "key_risks": ["risk 1", "risk 2", "..."],
   "key_levers": ["lever 1", "lever 2", "..."],
-  "rationale": "factual analysis of fit and odds (no scene narration)"
+  "rationale": "factual analysis of fit and odds (no scene narration)",
+  "score_confidence": 0.0-1.0,
+  "confidence_basis": "grounded | inferred | insufficient_evidence"
 }}"""
 
 

--- a/app/schemas/quick_sim.py
+++ b/app/schemas/quick_sim.py
@@ -231,8 +231,7 @@ class QuickSimMetrics(BaseModel):
     confidence_basis: ConfidenceBasis = Field(
         default=ConfidenceBasis.INFERRED,
         description=(
-            "grounded | inferred | insufficient_evidence — never a fabricated "
-            "mid-range fill."
+            "grounded | inferred | insufficient_evidence — never a fabricated mid-range fill."
         ),
     )
 

--- a/app/schemas/quick_sim.py
+++ b/app/schemas/quick_sim.py
@@ -30,9 +30,55 @@ Tests:
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 from pydantic import AliasChoices, BaseModel, Field
+
+
+class ConfidenceBasis(str, Enum):
+    """Where a :class:`QuickSimMetrics` score's confidence comes from.
+
+    Fail-closed scoring discipline: a breadth-tier quick-sim score that
+    cannot be honestly grounded in the run must be *flagged*, never
+    fabricated as a confident mid-range number. ``insufficient_evidence``
+    is that flag — it tells the selection page to down-rank the entry
+    rather than mix it in at face value.
+
+    Members:
+        GROUNDED: Anchored in real opportunity facts AND a usable scene.
+        INFERRED: Reasoned from partial signal; some fields were missing.
+        INSUFFICIENT_EVIDENCE: Nothing real to anchor on — the scores are
+            not trustworthy. Forced by :func:`apply_confidence_floor` when
+            the inputs are empty/no-op, regardless of the model's self-report.
+    """
+
+    GROUNDED = "grounded"
+    INFERRED = "inferred"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+
+
+# Default self-reported confidence when the model omits the field (additive
+# contract: older callers that never sent score_confidence still parse).
+DEFAULT_SCORE_CONFIDENCE = 0.5
+
+# Hard cap applied to score_confidence when the deterministic post-check
+# decides the inputs cannot support a grounded assessment. Kept low so the
+# selection page reliably sorts these below grounded/inferred entries; this is
+# NOT a fabricated mid-range fill — it is an explicit "do not trust" flag that
+# travels with confidence_basis == insufficient_evidence.
+INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP = 0.1
+
+# The two no-op fallback strings emitted by
+# ``find_money.py::summarize_tdf_for_metrics`` when the scene pipeline
+# produced nothing usable. A scene_context equal to either of these carries no
+# real signal, so the metrics call had nothing to anchor on.
+NO_OP_SCENE_CONTEXTS = frozenset(
+    {
+        "(no scene context available)",
+        "(scene pipeline returned no usable summary)",
+    }
+)
 
 
 class OpportunityIn(BaseModel):
@@ -150,6 +196,20 @@ class QuickSimMetrics(BaseModel):
             materially raise the probability of award.
         rationale: One-sentence summary of why these numbers, anchored
             in the future-moment scene.
+        score_confidence: How much the three 0–1 scores can be trusted
+            (0–1). Fail-closed discipline: the model self-reports this,
+            but the deterministic post-check
+            (:func:`apply_confidence_floor`) can only ever *lower* it —
+            never raise it past what the inputs actually support. A
+            no-signal assessment must NOT emit a confident mid-range
+            number; it carries a capped confidence and an
+            ``insufficient_evidence`` basis instead.
+        confidence_basis: Where the confidence comes from —
+            ``grounded`` (anchored in real opportunity facts and a usable
+            scene), ``inferred`` (reasoned from partial signal), or
+            ``insufficient_evidence`` (nothing real to anchor on; the
+            scores are not trustworthy and the selection page should
+            down-rank, not face-value-rank, this entry).
     """
 
     probability_of_award: float = Field(..., ge=0.0, le=1.0)
@@ -159,6 +219,140 @@ class QuickSimMetrics(BaseModel):
     key_risks: list[str] = Field(default_factory=list, max_length=5)
     key_levers: list[str] = Field(default_factory=list, max_length=5)
     rationale: str | None = Field(default=None, max_length=800)
+    score_confidence: float = Field(
+        default=DEFAULT_SCORE_CONFIDENCE,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Trust in the three scores (0–1). The deterministic post-check "
+            "can only lower this, never raise it (fail-closed)."
+        ),
+    )
+    confidence_basis: ConfidenceBasis = Field(
+        default=ConfidenceBasis.INFERRED,
+        description=(
+            "grounded | inferred | insufficient_evidence — never a fabricated "
+            "mid-range fill."
+        ),
+    )
+
+
+def opportunity_has_anchorable_fields(opportunity: dict[str, Any]) -> bool:
+    """Return True if an opportunity stub carries any field worth assessing.
+
+    A real fit assessment needs *something* to read: a summary, an amount,
+    or a deadline. A stub with none of those three (title-only) gives the
+    metrics agent nothing to ground on. ``title`` alone does NOT count —
+    every stub has a title, so it carries no discriminating signal.
+
+    Args:
+        opportunity: Opportunity stub dict (``summary`` / ``amount`` /
+            ``deadline`` / ``title`` / ...). Missing or empty values are
+            treated as absent.
+
+    Returns:
+        True if at least one of ``summary`` / ``amount`` / ``deadline`` is
+        present and non-empty.
+    """
+
+    def _present(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        # Numeric amounts (incl. 0) and other non-string truthy stubs count
+        # as present; only None / empty-string are treated as absent.
+        return True
+
+    return (
+        _present(opportunity.get("summary"))
+        or _present(opportunity.get("amount"))
+        or _present(opportunity.get("deadline"))
+    )
+
+
+def scene_context_is_no_op(scene_context: str | None) -> bool:
+    """Return True if a scene_context is one of the no-op fallback strings.
+
+    ``find_money.py::summarize_tdf_for_metrics`` emits a fixed fallback
+    string when the scene pipeline produced nothing usable. Such a context
+    gives the metrics agent no real anchor.
+
+    Args:
+        scene_context: The scene summary fed to the metrics agent.
+
+    Returns:
+        True if the context is empty or exactly one of the known no-op
+        fallbacks.
+    """
+    if not scene_context:
+        return True
+    stripped = scene_context.strip()
+    if not stripped:
+        return True
+    return stripped in NO_OP_SCENE_CONTEXTS
+
+
+def apply_confidence_floor(
+    metrics: QuickSimMetrics,
+    *,
+    opportunity: dict[str, Any],
+    scene_context: str | None,
+) -> QuickSimMetrics:
+    """Fail-closed post-check: cap confidence to what the inputs support.
+
+    Pure function (no I/O, no LLM). Inspects the *inputs* the metrics call
+    actually had — opportunity-stub completeness and whether the
+    ``scene_context`` is a no-op fallback — and **only ever lowers**
+    ``score_confidence`` / forces ``confidence_basis``. The model cannot
+    talk its way up past what the evidence supports.
+
+    The fail-closed trigger is deliberately strict: when the opportunity
+    stub has no anchorable field (no summary AND no amount AND no deadline)
+    **and** the scene_context is the no-op fallback, the call had nothing
+    real to anchor on. In that case confidence is capped at
+    :data:`INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP` and the basis is forced to
+    :attr:`ConfidenceBasis.INSUFFICIENT_EVIDENCE`, regardless of what the
+    model self-reported. This is the "abstain" path — the entry is kept
+    (1:1 pairing preserved) but flagged so the selection page down-ranks it
+    rather than mixing a fabricated mid-range number in at face value.
+
+    When evidence IS present, this function never *raises* confidence: it
+    leaves the model's self-report intact (PR-01 calibrates whether the
+    numbers are right; this PR makes the score honest about its own
+    uncertainty). It also clamps any out-of-band self-report and downgrades
+    a self-claimed ``grounded`` basis to ``inferred`` when the scene was a
+    no-op fallback — a grounded claim with no scene cannot stand.
+
+    Args:
+        metrics: The :class:`QuickSimMetrics` the LLM returned.
+        opportunity: The opportunity stub the call was run against.
+        scene_context: The scene summary fed to the metrics call.
+
+    Returns:
+        A new :class:`QuickSimMetrics` with confidence fields adjusted
+        downward as needed. The input is not mutated.
+    """
+    no_anchor = not opportunity_has_anchorable_fields(opportunity)
+    no_scene = scene_context_is_no_op(scene_context)
+
+    new_confidence = metrics.score_confidence
+    new_basis = metrics.confidence_basis
+
+    if no_anchor and no_scene:
+        # Nothing real to anchor on — fail closed. Cap (only lower) and flag.
+        new_confidence = min(new_confidence, INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP)
+        new_basis = ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    elif no_scene and new_basis == ConfidenceBasis.GROUNDED:
+        # A "grounded" self-report cannot stand without a usable scene; the
+        # opportunity stub still carries signal, so downgrade rather than flag.
+        new_basis = ConfidenceBasis.INFERRED
+
+    if new_confidence == metrics.score_confidence and new_basis == metrics.confidence_basis:
+        return metrics
+    return metrics.model_copy(
+        update={"score_confidence": new_confidence, "confidence_basis": new_basis}
+    )
 
 
 class QuickSimTdfEntry(BaseModel):
@@ -185,6 +379,14 @@ class QuickSimTdfEntry(BaseModel):
             or ``None`` when the opportunity failed.
         fit_score: ``fit_score`` from the metrics agent, or ``None``.
         effort_score: ``effort_score`` from the metrics agent, or ``None``.
+        score_confidence: ``score_confidence`` from the metrics agent
+            (after the fail-closed post-check), or ``None`` on failure.
+            Mirrored onto the flat entry so the selection page can sort
+            without reaching into the nested ``quick_sim`` payload.
+        confidence_basis: ``confidence_basis`` from the metrics agent
+            (``grounded`` / ``inferred`` / ``insufficient_evidence``), or
+            ``None`` on failure. An ``insufficient_evidence`` entry is kept
+            in the batch (1:1 pairing) but flagged for down-ranking.
         amount_usd: Opportunity amount (number or free-text), if any.
         source: ``"flash-quick-sim"`` on success,
             ``"flash-quick-sim-error"`` when the opportunity failed.
@@ -203,6 +405,8 @@ class QuickSimTdfEntry(BaseModel):
     probability: float | None = None
     fit_score: float | None = None
     effort_score: float | None = None
+    score_confidence: float | None = None
+    confidence_basis: ConfidenceBasis | None = None
     amount_usd: float | int | str | None = None
     source: str
     tdf: dict[str, Any] | None = None

--- a/tests/unit/test_agents/test_quick_sim_fail_closed.py
+++ b/tests/unit/test_agents/test_quick_sim_fail_closed.py
@@ -1,0 +1,106 @@
+"""Agent-level tests for fail-closed quick-sim scoring (PR-02).
+
+These exercise ``QuickSimMetricsAgent.run`` end to end, stubbing ONLY the
+outbound LLM HTTP boundary (``router.call_structured``) — the single
+stubbable boundary allowed by repo policy. No real tokens are spent.
+
+The point: even when the model self-reports a confident, grounded score, a
+call that had nothing real to anchor on (empty opportunity stub + no-op
+scene_context) must come back flagged ``insufficient_evidence`` with a capped
+confidence. A valid call is left untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agents.quick_sim import QuickSimMetricsAgent, QuickSimMetricsInput
+from app.config import ProviderType
+from app.core.providers import LLMResponse
+from app.schemas.quick_sim import (
+    INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP,
+    ConfidenceBasis,
+    QuickSimMetrics,
+)
+
+NO_OP_SCENE = "(no scene context available)"
+
+
+class _StubRouter:
+    """Stand-in for the LLM router that returns a fixed structured response.
+
+    This stubs the outbound provider HTTP call only — the agent's own
+    post-processing (the fail-closed confidence floor) runs for real.
+    """
+
+    def __init__(self, content: QuickSimMetrics) -> None:
+        self._content = content
+        self.calls = 0
+
+    async def call_structured(self, **kwargs):
+        self.calls += 1
+        return LLMResponse(
+            content=self._content,
+            raw_response=None,
+            model="stub-model",
+            provider=ProviderType.GOOGLE,
+            usage={"input_tokens": 0, "output_tokens": 0},
+            latency_ms=1,
+        )
+
+
+def _confident_grounded() -> QuickSimMetrics:
+    # The model claims a confident, grounded score regardless of the inputs.
+    return QuickSimMetrics(
+        probability_of_award=0.45,
+        fit_score=0.55,
+        effort_score=0.5,
+        effort_estimate="moderate — 20h proposal",
+        score_confidence=0.92,
+        confidence_basis=ConfidenceBasis.GROUNDED,
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_signal_call_is_flagged_insufficient_evidence() -> None:
+    router = _StubRouter(_confident_grounded())
+    agent = QuickSimMetricsAgent(router=router)  # type: ignore[arg-type]
+
+    result = await agent.run(
+        QuickSimMetricsInput(
+            goal="$50k operating grant by Sept 2026",
+            opportunity={"title": "Bare Opportunity"},  # no summary/amount/deadline
+            scene_context=NO_OP_SCENE,
+        )
+    )
+
+    assert router.calls == 1
+    assert result.success
+    assert result.content is not None
+    # Fail-closed: the confident grounded self-report is overridden.
+    assert result.content.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    assert result.content.score_confidence <= INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP
+
+
+@pytest.mark.asyncio
+async def test_valid_call_keeps_grounded_confidence() -> None:
+    router = _StubRouter(_confident_grounded())
+    agent = QuickSimMetricsAgent(router=router)  # type: ignore[arg-type]
+
+    result = await agent.run(
+        QuickSimMetricsInput(
+            goal="$50k operating grant by Sept 2026",
+            opportunity={
+                "title": "Climate Action Fund",
+                "summary": "Annual $10-50k grants for climate work",
+                "amount": 50000,
+                "deadline": "2026-09-01",
+            },
+            scene_context="Setting: a tense grant-review boardroom; Stakes: $50k decision",
+        )
+    )
+
+    assert result.success
+    assert result.content is not None
+    assert result.content.confidence_basis == ConfidenceBasis.GROUNDED
+    assert result.content.score_confidence == pytest.approx(0.92)

--- a/tests/unit/test_schemas_quick_sim_confidence.py
+++ b/tests/unit/test_schemas_quick_sim_confidence.py
@@ -1,0 +1,243 @@
+"""Unit tests for fail-closed quick-sim confidence (PR-02).
+
+Covers the deterministic, pure post-check that keeps a no-signal quick-sim
+score from emitting a confident-looking mid-range number:
+
+    - ``opportunity_has_anchorable_fields`` — what counts as real signal.
+    - ``scene_context_is_no_op`` — detecting the scene-pipeline fallbacks.
+    - ``apply_confidence_floor`` — the fail-closed cap (only ever lowers).
+    - schema round-trips: new fields are additive/optional (the old payload
+      shape still parses), and ``QuickSimTdfEntry`` threads them through.
+
+No LLM tokens are spent here — everything is pure logic / schema validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.quick_sim import (
+    INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP,
+    ConfidenceBasis,
+    QuickSimMetrics,
+    QuickSimTdfEntry,
+    apply_confidence_floor,
+    opportunity_has_anchorable_fields,
+    scene_context_is_no_op,
+)
+
+NO_OP_SCENE = "(no scene context available)"
+NO_OP_SCENE_2 = "(scene pipeline returned no usable summary)"
+
+
+def _metrics(**overrides) -> QuickSimMetrics:
+    base = {
+        "probability_of_award": 0.2,
+        "fit_score": 0.4,
+        "effort_score": 0.5,
+        "effort_estimate": "low — 4h application",
+    }
+    base.update(overrides)
+    return QuickSimMetrics(**base)
+
+
+# ---------------------------------------------------------------------------
+# opportunity_has_anchorable_fields
+# ---------------------------------------------------------------------------
+
+
+def test_title_only_stub_has_no_anchorable_fields() -> None:
+    assert opportunity_has_anchorable_fields({"title": "Climate Fund"}) is False
+
+
+def test_empty_stub_has_no_anchorable_fields() -> None:
+    assert opportunity_has_anchorable_fields({}) is False
+
+
+@pytest.mark.parametrize(
+    "stub",
+    [
+        {"title": "X", "summary": "Annual $10-50k grants for climate work"},
+        {"title": "X", "amount": 50000},
+        {"title": "X", "amount": "$25,000"},
+        {"title": "X", "deadline": "2026-09-01"},
+    ],
+)
+def test_any_real_field_makes_stub_anchorable(stub: dict) -> None:
+    assert opportunity_has_anchorable_fields(stub) is True
+
+
+def test_zero_amount_counts_as_present() -> None:
+    # A numeric 0 amount is still a stated value, not a missing field.
+    assert opportunity_has_anchorable_fields({"title": "X", "amount": 0}) is True
+
+
+def test_blank_string_fields_do_not_count() -> None:
+    assert (
+        opportunity_has_anchorable_fields(
+            {"title": "X", "summary": "   ", "deadline": "", "amount": None}
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# scene_context_is_no_op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scene", [NO_OP_SCENE, NO_OP_SCENE_2, "", None, "   "])
+def test_no_op_scene_detection(scene) -> None:
+    assert scene_context_is_no_op(scene) is True
+
+
+def test_real_scene_is_not_no_op() -> None:
+    assert scene_context_is_no_op("Setting: a tense boardroom; Stakes: $50k") is False
+
+
+# ---------------------------------------------------------------------------
+# apply_confidence_floor — fail-closed behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_no_signal_path_caps_confidence_and_flags() -> None:
+    """Empty stub + no-op scene -> insufficient_evidence, capped confidence.
+
+    Regardless of how confident the model claimed to be.
+    """
+    m = _metrics(score_confidence=0.95, confidence_basis=ConfidenceBasis.GROUNDED)
+    out = apply_confidence_floor(
+        m, opportunity={"title": "Bare"}, scene_context=NO_OP_SCENE
+    )
+    assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    assert out.score_confidence <= INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP
+
+
+def test_no_signal_with_second_fallback_string() -> None:
+    m = _metrics(score_confidence=0.8, confidence_basis=ConfidenceBasis.INFERRED)
+    out = apply_confidence_floor(
+        m, opportunity={}, scene_context=NO_OP_SCENE_2
+    )
+    assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    assert out.score_confidence <= INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP
+
+
+def test_floor_only_lowers_never_raises_confidence() -> None:
+    """An already-low self-report is not bumped UP by the cap."""
+    m = _metrics(
+        score_confidence=0.02, confidence_basis=ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    )
+    out = apply_confidence_floor(m, opportunity={}, scene_context=NO_OP_SCENE)
+    assert out.score_confidence == pytest.approx(0.02)
+    assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
+
+
+def test_valid_path_leaves_confidence_untouched() -> None:
+    """Rich stub + real scene -> model's grounded self-report is preserved."""
+    m = _metrics(score_confidence=0.82, confidence_basis=ConfidenceBasis.GROUNDED)
+    rich = {
+        "title": "Climate Action Fund",
+        "summary": "Annual $10-50k grants for climate work",
+        "amount": 50000,
+        "deadline": "2026-09-01",
+    }
+    out = apply_confidence_floor(
+        m, opportunity=rich, scene_context="Setting: boardroom; Stakes: $50k on the line"
+    )
+    assert out.score_confidence == pytest.approx(0.82)
+    assert out.confidence_basis == ConfidenceBasis.GROUNDED
+    # Pure: no mutation of the input object.
+    assert m.confidence_basis == ConfidenceBasis.GROUNDED
+
+
+def test_grounded_claim_downgraded_when_scene_missing_but_stub_has_signal() -> None:
+    """A 'grounded' claim cannot stand without a usable scene.
+
+    The opportunity stub still carries signal (so NOT insufficient_evidence),
+    but the basis is downgraded grounded -> inferred.
+    """
+    m = _metrics(score_confidence=0.7, confidence_basis=ConfidenceBasis.GROUNDED)
+    out = apply_confidence_floor(
+        m, opportunity={"title": "X", "amount": 50000}, scene_context=NO_OP_SCENE
+    )
+    assert out.confidence_basis == ConfidenceBasis.INFERRED
+    # Confidence is not raised; left as the (still un-capped) self-report.
+    assert out.score_confidence == pytest.approx(0.7)
+
+
+def test_no_signal_never_emits_fabricated_midrange() -> None:
+    """The fail-closed cap is well below the 0.5 'fabricated mid-range' band."""
+    assert INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP < 0.5
+
+
+# ---------------------------------------------------------------------------
+# schema round-trips — additive / optional contract
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_payload_without_new_fields_still_parses() -> None:
+    """Old shape (no score_confidence / confidence_basis) parses with defaults."""
+    m = QuickSimMetrics(
+        probability_of_award=0.3,
+        fit_score=0.4,
+        effort_score=0.6,
+        effort_estimate="moderate — 20h proposal",
+    )
+    assert 0.0 <= m.score_confidence <= 1.0
+    assert m.confidence_basis in set(ConfidenceBasis)
+
+
+def test_metrics_round_trip_with_new_fields() -> None:
+    m = _metrics(score_confidence=0.66, confidence_basis=ConfidenceBasis.INFERRED)
+    dumped = m.model_dump()
+    assert dumped["score_confidence"] == pytest.approx(0.66)
+    assert dumped["confidence_basis"] == "inferred"
+    reloaded = QuickSimMetrics.model_validate(dumped)
+    assert reloaded.confidence_basis == ConfidenceBasis.INFERRED
+
+
+def test_confidence_basis_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError):
+        QuickSimMetrics(
+            probability_of_award=0.3,
+            fit_score=0.4,
+            effort_score=0.6,
+            effort_estimate="x",
+            confidence_basis="totally_made_up",
+        )
+
+
+def test_score_confidence_out_of_band_rejected() -> None:
+    with pytest.raises(ValueError):
+        QuickSimMetrics(
+            probability_of_award=0.3,
+            fit_score=0.4,
+            effort_score=0.6,
+            effort_estimate="x",
+            score_confidence=1.5,
+        )
+
+
+def test_tdf_entry_threads_confidence_fields() -> None:
+    entry = QuickSimTdfEntry(
+        tdf_ref="flash:quick:0",
+        opportunity_index=0,
+        title="Climate Fund",
+        source="flash-quick-sim",
+        score_confidence=0.1,
+        confidence_basis=ConfidenceBasis.INSUFFICIENT_EVIDENCE,
+    )
+    assert entry.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
+    assert entry.score_confidence == pytest.approx(0.1)
+
+
+def test_tdf_entry_without_confidence_fields_still_parses() -> None:
+    """Existing _seed_quick_sim_tdfs pairing contract is unbroken."""
+    entry = QuickSimTdfEntry(
+        tdf_ref="flash:quick:1",
+        opportunity_index=1,
+        title="X",
+        source="flash-quick-sim-error",
+    )
+    assert entry.score_confidence is None
+    assert entry.confidence_basis is None

--- a/tests/unit/test_schemas_quick_sim_confidence.py
+++ b/tests/unit/test_schemas_quick_sim_confidence.py
@@ -106,27 +106,21 @@ def test_no_signal_path_caps_confidence_and_flags() -> None:
     Regardless of how confident the model claimed to be.
     """
     m = _metrics(score_confidence=0.95, confidence_basis=ConfidenceBasis.GROUNDED)
-    out = apply_confidence_floor(
-        m, opportunity={"title": "Bare"}, scene_context=NO_OP_SCENE
-    )
+    out = apply_confidence_floor(m, opportunity={"title": "Bare"}, scene_context=NO_OP_SCENE)
     assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
     assert out.score_confidence <= INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP
 
 
 def test_no_signal_with_second_fallback_string() -> None:
     m = _metrics(score_confidence=0.8, confidence_basis=ConfidenceBasis.INFERRED)
-    out = apply_confidence_floor(
-        m, opportunity={}, scene_context=NO_OP_SCENE_2
-    )
+    out = apply_confidence_floor(m, opportunity={}, scene_context=NO_OP_SCENE_2)
     assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE
     assert out.score_confidence <= INSUFFICIENT_EVIDENCE_CONFIDENCE_CAP
 
 
 def test_floor_only_lowers_never_raises_confidence() -> None:
     """An already-low self-report is not bumped UP by the cap."""
-    m = _metrics(
-        score_confidence=0.02, confidence_basis=ConfidenceBasis.INSUFFICIENT_EVIDENCE
-    )
+    m = _metrics(score_confidence=0.02, confidence_basis=ConfidenceBasis.INSUFFICIENT_EVIDENCE)
     out = apply_confidence_floor(m, opportunity={}, scene_context=NO_OP_SCENE)
     assert out.score_confidence == pytest.approx(0.02)
     assert out.confidence_basis == ConfidenceBasis.INSUFFICIENT_EVIDENCE


### PR DESCRIPTION
Adds fail-closed quick-sim scoring with per-metric confidence.

Note: merge != production deploy (live Flash deploys from a private fork, not this public upstream).
Swarm-built and adversarially verified.