### PR TITLE
feat: model-slug liveness guard over VerifiedModels + quick-sim depth dial

### DIFF
--- a/app/api/v1/find_money.py
+++ b/app/api/v1/find_money.py
@@ -71,6 +71,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/find-money", tags=["find-money"])
 
 
+class DeadFrontierSlugError(RuntimeError):
+    """Raised when the resolved ``frontier``-tier slug is not in the live catalog.
+
+    A dead frontier slug must NOT silently degrade to a fallback model — the
+    user explicitly (and at higher cost) requested the frontier tier. The guard
+    raises this so :func:`_simulate_one` fails the affected opportunity with an
+    honest error and the batch refunds the credits, rather than emitting a
+    garbage score from a deprecated model (the ecosystem-wide dead-slug failure
+    mode documented in ``reference_dead_model_slug_failure_mode.md``).
+    """
+
+
 # Module-level set of in-flight background image-generation tasks. Keeping a
 # reference here prevents the asyncio event loop from garbage-collecting the
 # task before it completes — see ``app/mcp_server.py`` for the same pattern.
@@ -174,20 +186,71 @@ def _resolve_quick_sim_text_model(depth: str | None) -> str:
     Falls back to :data:`_QUICK_SIM_TEXT_MODEL` when ``depth`` is absent
     or unrecognised, preserving today's default behaviour (no regression).
 
+    **Model-slug liveness guard (PR-04).** Before returning a resolved slug,
+    it is liveness-checked against the live provider catalog
+    (``VerifiedModels.is_slug_live``). A statically-hardcoded slug that has
+    since been silently deprecated at the provider would otherwise 404 →
+    empty/garbled scores the user paid for. The guard's behaviour by tier:
+
+    * non-``frontier`` (default / ``fast`` / ``standard`` / ``deep``): a dead
+      slug emits a loud ``WARNING`` and falls back to the known-live default
+      (:data:`_QUICK_SIM_TEXT_MODEL`).
+    * ``frontier``: a dead slug raises :class:`DeadFrontierSlugError` — the
+      paid frontier request fails loud + refunds rather than degrading to a
+      garbage score.
+
+    The liveness check is set-membership against a *cached* catalog (one
+    bounded fetch per run via the model registry), not a per-opportunity call.
+    When no catalog is loaded (offline / no key) the check fails *soft* and the
+    slug is used unchanged.
+
     Args:
         depth: One of ``"fast"``, ``"standard"``, ``"deep"``, ``"frontier"``,
             or ``None``.
 
     Returns:
         A model ID string accepted by :class:`GenerationPipeline`.
+
+    Raises:
+        DeadFrontierSlugError: When ``depth == "frontier"`` and the resolved
+            frontier slug is absent from the live catalog.
     """
+    from app.config import VerifiedModels
+
+    is_frontier = depth is not None and depth.lower() == "frontier"
+
     if depth is None:
-        return _QUICK_SIM_TEXT_MODEL
-    resolved = _DEPTH_TO_TEXT_MODEL.get(depth.lower())
-    if resolved is None:
-        logger.warning("quick_sim: unrecognised depth %r, using default model", depth)
-        return _QUICK_SIM_TEXT_MODEL
-    return resolved
+        resolved = _QUICK_SIM_TEXT_MODEL
+    else:
+        resolved = _DEPTH_TO_TEXT_MODEL.get(depth.lower())
+        if resolved is None:
+            logger.warning("quick_sim: unrecognised depth %r, using default model", depth)
+            resolved = _QUICK_SIM_TEXT_MODEL
+
+    # Liveness guard: confirm the resolved slug is still served by its provider.
+    if VerifiedModels.is_slug_live(resolved):
+        return resolved
+
+    if is_frontier:
+        # Never silently degrade a paid frontier request to a fallback model.
+        logger.error(
+            "quick_sim: frontier slug %r is DEAD (absent from live catalog) — "
+            "failing the opportunity loud + refunding rather than emitting a garbage score",
+            resolved,
+        )
+        raise DeadFrontierSlugError(
+            f"frontier model {resolved!r} is not live in the provider catalog"
+        )
+
+    # Non-frontier: loud WARNING + fallback to the known-live default.
+    logger.warning(
+        "quick_sim: depth %r slug %r is DEAD (absent from live catalog) — "
+        "falling back to default live model %r",
+        depth,
+        resolved,
+        _QUICK_SIM_TEXT_MODEL,
+    )
+    return _QUICK_SIM_TEXT_MODEL
 
 
 # ---------------------------------------------------------------------------
@@ -569,9 +632,22 @@ async def _simulate_one(
     t0 = time.perf_counter()
     opp_dict = opportunity.model_dump()
 
-    # Resolve the text model from the depth dial (B1 spec). Falls back to
-    # the module-level default when depth is absent or unrecognised.
-    text_model = _resolve_quick_sim_text_model(depth)
+    # Resolve the text model from the depth dial (B1 spec), with the PR-04
+    # model-slug liveness guard applied. Falls back to the module-level
+    # default when depth is absent/unrecognised or when a non-frontier slug
+    # is dead; a DEAD frontier slug raises DeadFrontierSlugError so this
+    # opportunity fails loud + refunds rather than emitting a garbage score.
+    try:
+        text_model = _resolve_quick_sim_text_model(depth)
+    except DeadFrontierSlugError as exc:
+        logger.error("quick_sim opportunity %d: %s", index, exc)
+        return {
+            "success": False,
+            "tdf": None,
+            "quick_sim": None,
+            "error": f"frontier model unavailable: {exc}",
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+        }
 
     # Lazy import — avoids pulling app.prompts at module import time, which
     # would force the test conftest to set every env var early.

--- a/app/config.py
+++ b/app/config.py
@@ -207,6 +207,81 @@ class VerifiedModels:
 
         return False
 
+    @classmethod
+    def provider_for(cls, model: str) -> "ProviderType":
+        """Infer the provider that serves ``model`` from the static lists.
+
+        OpenRouter slugs are namespaced (``vendor/model``); Google-native
+        slugs are bare (``gemini-2.5-flash``). Stability image slugs are
+        treated as STABILITY. Defaults to GOOGLE for an unknown bare slug.
+        """
+        if model in cls.OPENROUTER_TEXT or "/" in model:
+            # stability-ai/* is an image slug routed via Stability, not OpenRouter
+            if model in cls.STABILITY_IMAGE:
+                return ProviderType.STABILITY
+            return ProviderType.OPENROUTER
+        if model in cls.STABILITY_IMAGE:
+            return ProviderType.STABILITY
+        return ProviderType.GOOGLE
+
+    @classmethod
+    def is_slug_live(cls, model: str, provider: "ProviderType | None" = None) -> bool:
+        """Liveness-check a *static* slug against the live provider catalog.
+
+        Unlike :meth:`is_verified_or_available` (which trusts static-list
+        membership), this consults the cached provider catalog so a slug that
+        was hardcoded but has since been deprecated at the provider is reported
+        DEAD. It only asserts death when a catalog is actually loaded for the
+        provider — with no catalog (offline / no key) it fails *soft* and
+        returns True, because absence of a catalog is not evidence a slug is
+        dead (see the model-registry ``has_catalog`` guard).
+
+        Args:
+            model: The model slug to check.
+            provider: Provider to check against; inferred from the slug when
+                omitted.
+
+        Returns:
+            True if the slug is live (or liveness can't be asserted); False
+            only when a catalog exists for the provider and the slug is absent.
+        """
+        if provider is None:
+            provider = cls.provider_for(model)
+        try:
+            from app.core.model_registry import OpenRouterModelRegistry
+
+            registry = OpenRouterModelRegistry.get_instance()
+        except Exception:
+            return True  # registry unavailable — fail soft
+        if not registry.has_catalog(provider):
+            return True  # no catalog loaded — cannot assert death, fail soft
+        return registry.is_slug_live(model, provider)
+
+    @classmethod
+    def all_configured_text_slugs(cls) -> list[tuple[str, "ProviderType"]]:
+        """Enumerate every configured text slug with its provider.
+
+        Used by the CI liveness guard so a dead slug in any static list /
+        depth map / fallback chain becomes a red CI rather than a silent
+        empty-score regression in production. Image slugs are out of scope
+        for the quick-sim guard (see PR-04 scope).
+        """
+        slugs: list[tuple[str, ProviderType]] = []
+        seen: set[str] = set()
+
+        def _add(slug: str, provider: ProviderType) -> None:
+            if slug and slug not in seen:
+                seen.add(slug)
+                slugs.append((slug, provider))
+
+        for s in cls.GOOGLE_TEXT:
+            _add(s, ProviderType.GOOGLE)
+        for s in cls.OPENROUTER_TEXT:
+            _add(s, ProviderType.OPENROUTER)
+        for s in cls.TEXT_FALLBACK_CHAIN:
+            _add(s, cls.provider_for(s))
+        return slugs
+
 
 # Quality Preset Configurations
 # =============================================================================

--- a/app/core/model_registry.py
+++ b/app/core/model_registry.py
@@ -10,13 +10,20 @@ falls back to existing hardcoded defaults. No existing behavior breaks.
 import asyncio
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    from app.config import ProviderType
 
 logger = logging.getLogger(__name__)
 
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+# Google Gen AI (Gemini Developer API) catalog endpoint. Returns models named
+# like ``models/gemini-2.5-flash``; we normalise the ``models/`` prefix away so
+# membership matches the bare slugs in VerifiedModels.GOOGLE_TEXT.
+GOOGLE_MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 _FETCH_TIMEOUT = 5.0  # seconds
 
 # Hardcoded defaults — used when registry has no data
@@ -31,8 +38,11 @@ class OpenRouterModelRegistry:
 
     def __init__(self) -> None:
         self._models: dict[str, dict[str, Any]] = {}
+        self._google_models: set[str] = set()
         self._last_refresh: float = 0.0
+        self._google_last_refresh: float = 0.0
         self._api_key: str | None = None
+        self._google_api_key: str | None = None
         self._refresh_task: asyncio.Task | None = None
 
     @classmethod
@@ -117,12 +127,95 @@ class OpenRouterModelRegistry:
             self._refresh_task = None
 
     def is_model_available(self, model_id: str) -> bool:
-        """Check if a model is in the cached list."""
+        """Check if a model is in the cached OpenRouter list."""
         return model_id in self._models
 
     @property
     def model_count(self) -> int:
         return len(self._models)
+
+    # ------------------------------------------------------------------
+    # Google-native catalog (liveness guard)
+    # ------------------------------------------------------------------
+    async def refresh_google(self, api_key: str | None = None) -> bool:
+        """Fetch the Google Gen AI model catalog and cache the bare slugs.
+
+        The Gemini Developer API lists models under names like
+        ``models/gemini-2.5-flash``; we strip the ``models/`` prefix so a
+        membership check against ``VerifiedModels.GOOGLE_TEXT`` (which holds
+        bare slugs like ``gemini-2.5-flash``) works.
+
+        One bounded fetch — cached for the life of the process. Returns True
+        on success, False on any failure (so callers can fail soft).
+        """
+        key = api_key or self._google_api_key
+        if key:
+            self._google_api_key = key
+        if not key:
+            return False
+        try:
+            async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT) as client:
+                resp = await client.get(
+                    GOOGLE_MODELS_URL,
+                    params={"key": key, "pageSize": 1000},
+                )
+                if resp.status_code != 200:
+                    logger.warning("Google models API returned %d", resp.status_code)
+                    return False
+                data = resp.json()
+                new_cache: set[str] = set()
+                for m in data.get("models", []):
+                    name = m.get("name") or m.get("baseModelId") or ""
+                    if name.startswith("models/"):
+                        name = name[len("models/") :]
+                    if name:
+                        new_cache.add(name)
+                self._google_models = new_cache
+                self._google_last_refresh = time.monotonic()
+                return True
+        except Exception as e:  # noqa: BLE001 — best-effort catalog fetch
+            logger.warning("Google model registry refresh failed: %s", e)
+            return False
+
+    @property
+    def google_model_count(self) -> int:
+        return len(self._google_models)
+
+    def is_google_model_available(self, model_id: str) -> bool:
+        """Check if a bare Google slug is present in the cached Google catalog."""
+        return model_id in self._google_models
+
+    def has_catalog(self, provider: "ProviderType") -> bool:
+        """Whether a live catalog has been loaded for ``provider``.
+
+        Liveness can only be *asserted* when a catalog is present. With no
+        catalog (offline / no key / unreachable), callers must fail soft —
+        we cannot claim a slug is dead just because we never fetched a list.
+        """
+        from app.config import ProviderType
+
+        if provider == ProviderType.GOOGLE:
+            return bool(self._google_models)
+        if provider == ProviderType.OPENROUTER:
+            return bool(self._models)
+        return False
+
+    def is_slug_live(self, model_id: str, provider: "ProviderType") -> bool:
+        """Liveness check: is ``model_id`` present in the live catalog for ``provider``?
+
+        IMPORTANT: only meaningful when :meth:`has_catalog` is True for that
+        provider. When no catalog is loaded this returns False — callers should
+        gate on ``has_catalog`` first and fail soft (not fail-closed) on a
+        missing catalog, but fail loud on a *dead* slug when a catalog exists.
+        """
+        from app.config import ProviderType
+
+        if provider == ProviderType.GOOGLE:
+            return model_id in self._google_models
+        if provider == ProviderType.OPENROUTER:
+            return model_id in self._models
+        # No live catalog for STABILITY here.
+        return False
 
     def get_best_text_model(self, prefer_free: bool = False) -> str | None:
         """Find the best available text model.

--- a/app/main.py
+++ b/app/main.py
@@ -116,6 +116,22 @@ async def lifespan(app: FastAPI):
         await registry.initialize(api_key=_openrouter_keys[0])
         registry.start_background_refresh(interval=3600)
 
+    # Warm the Google-native catalog so the model-slug liveness guard
+    # (PR-04) can assert that GOOGLE_TEXT slugs like gemini-2.5-flash are
+    # actually live. One bounded fetch per run; failure is logged and the
+    # guard fails soft (no catalog → cannot assert a slug is dead).
+    if _settings.GOOGLE_API_KEY:
+        from app.core.model_registry import OpenRouterModelRegistry
+
+        registry = OpenRouterModelRegistry.get_instance()
+        ok = await registry.refresh_google(api_key=_settings.GOOGLE_API_KEY)
+        if ok:
+            logger.info(
+                "Google model catalog warmed: %d models", registry.google_model_count
+            )
+        else:
+            logger.warning("Google model catalog unreachable; liveness guard fails soft")
+
     # Start the MCP Streamable HTTP session manager so the /mcp sub-app
     # works.  The context manager must wrap ``yield`` so the transport is
     # torn down cleanly on shutdown.

--- a/app/main.py
+++ b/app/main.py
@@ -126,9 +126,7 @@ async def lifespan(app: FastAPI):
         registry = OpenRouterModelRegistry.get_instance()
         ok = await registry.refresh_google(api_key=_settings.GOOGLE_API_KEY)
         if ok:
-            logger.info(
-                "Google model catalog warmed: %d models", registry.google_model_count
-            )
+            logger.info("Google model catalog warmed: %d models", registry.google_model_count)
         else:
             logger.warning("Google model catalog unreachable; liveness guard fails soft")
 

--- a/tests/unit/test_model_slug_liveness.py
+++ b/tests/unit/test_model_slug_liveness.py
@@ -1,0 +1,292 @@
+"""Model-slug liveness guard (PR-04).
+
+Guards the static ``VerifiedModels`` slug lists + the Find Money quick-sim
+``depth`` dial against the ecosystem-wide dead-slug failure mode: a hardcoded
+slug that is silently deprecated at the provider 404s → empty/garbled scores
+the user paid for (see ``reference_dead_model_slug_failure_mode.md``).
+
+No mocks except the single outbound catalog HTTP GET (the only stubbable
+boundary per repo policy). Liveness is a set-membership check against a cached
+catalog, so the unit-level tests populate the cache directly — no HTTP, no
+LLM tokens.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.config import ProviderType, VerifiedModels
+from app.core.model_registry import OpenRouterModelRegistry
+
+# A realistic Google Gen AI catalog response. Names carry the ``models/``
+# prefix exactly as the live API returns them.
+SAMPLE_GOOGLE_RESPONSE = {
+    "models": [
+        {"name": "models/gemini-2.5-flash", "displayName": "Gemini 2.5 Flash"},
+        {"name": "models/gemini-2.0-flash", "displayName": "Gemini 2.0 Flash"},
+        {"name": "models/gemini-2.5-flash-image", "displayName": "Nano Banana"},
+    ]
+}
+
+SAMPLE_OPENROUTER_RESPONSE = {
+    "data": [
+        {"id": "anthropic/claude-opus-4.8", "name": "Claude Opus 4.8"},
+        {"id": "google/gemini-2.0-flash-001", "name": "Gemini 2.0 Flash"},
+        {"id": "google/gemini-3-flash-preview", "name": "Gemini 3 Flash Preview"},
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    OpenRouterModelRegistry.reset()
+    yield
+    OpenRouterModelRegistry.reset()
+
+
+def _populate_google(registry: OpenRouterModelRegistry, names: list[str]) -> None:
+    """Directly seed the Google catalog cache (no HTTP)."""
+    registry._google_models = set(names)
+
+
+def _populate_openrouter(registry: OpenRouterModelRegistry, ids: list[str]) -> None:
+    for i in ids:
+        registry._models[i] = {"id": i}
+
+
+# ---------------------------------------------------------------------------
+# Registry-level liveness primitives
+# ---------------------------------------------------------------------------
+@pytest.mark.fast
+class TestRegistryLiveness:
+    def test_google_catalog_membership_after_refresh(self):
+        """refresh_google strips the models/ prefix and caches bare slugs."""
+        registry = OpenRouterModelRegistry.get_instance()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_GOOGLE_RESPONSE
+
+        with patch("app.core.model_registry.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            import asyncio
+
+            ok = asyncio.run(registry.refresh_google(api_key="test-key"))
+
+        assert ok is True
+        assert registry.google_model_count == 3
+        assert registry.is_google_model_available("gemini-2.5-flash")
+        assert not registry.is_google_model_available("models/gemini-2.5-flash")
+
+    def test_refresh_google_no_key_returns_false(self):
+        registry = OpenRouterModelRegistry.get_instance()
+        import asyncio
+
+        assert asyncio.run(registry.refresh_google(api_key=None)) is False
+
+    def test_refresh_google_non_200_graceful(self):
+        registry = OpenRouterModelRegistry.get_instance()
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch("app.core.model_registry.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            import asyncio
+
+            ok = asyncio.run(registry.refresh_google(api_key="test-key"))
+        assert ok is False
+        assert registry.google_model_count == 0
+
+    def test_has_catalog(self):
+        registry = OpenRouterModelRegistry.get_instance()
+        assert not registry.has_catalog(ProviderType.GOOGLE)
+        assert not registry.has_catalog(ProviderType.OPENROUTER)
+        _populate_google(registry, ["gemini-2.5-flash"])
+        _populate_openrouter(registry, ["anthropic/claude-opus-4.8"])
+        assert registry.has_catalog(ProviderType.GOOGLE)
+        assert registry.has_catalog(ProviderType.OPENROUTER)
+        # Stability has no live catalog here.
+        assert not registry.has_catalog(ProviderType.STABILITY)
+
+    def test_is_slug_live_google(self):
+        registry = OpenRouterModelRegistry.get_instance()
+        _populate_google(registry, ["gemini-2.5-flash", "gemini-2.0-flash"])
+        assert registry.is_slug_live("gemini-2.5-flash", ProviderType.GOOGLE)
+        # A fabricated / deprecated slug is DEAD.
+        assert not registry.is_slug_live("gemini-9.9-ultra", ProviderType.GOOGLE)
+
+    def test_is_slug_live_openrouter(self):
+        registry = OpenRouterModelRegistry.get_instance()
+        _populate_openrouter(registry, ["anthropic/claude-opus-4.8"])
+        assert registry.is_slug_live("anthropic/claude-opus-4.8", ProviderType.OPENROUTER)
+        assert not registry.is_slug_live("anthropic/claude-3-5-haiku-20241022", ProviderType.OPENROUTER)
+
+
+# ---------------------------------------------------------------------------
+# VerifiedModels.is_slug_live — the config-level classmethod
+# ---------------------------------------------------------------------------
+@pytest.mark.fast
+class TestVerifiedModelsLiveness:
+    def test_provider_inference(self):
+        assert VerifiedModels.provider_for("gemini-2.5-flash") == ProviderType.GOOGLE
+        assert VerifiedModels.provider_for("anthropic/claude-opus-4.8") == ProviderType.OPENROUTER
+        assert VerifiedModels.provider_for("stability-ai/sd3.5-large") == ProviderType.STABILITY
+
+    def test_live_slug_passes(self):
+        """A slug present in the live catalog passes the liveness check."""
+        registry = OpenRouterModelRegistry.get_instance()
+        _populate_google(registry, ["gemini-2.5-flash", "gemini-2.0-flash"])
+        _populate_openrouter(registry, ["anthropic/claude-opus-4.8"])
+
+        assert VerifiedModels.is_slug_live("gemini-2.5-flash")
+        assert VerifiedModels.is_slug_live("anthropic/claude-opus-4.8")
+
+    def test_dead_slug_fails(self):
+        """A fabricated slug, with a catalog loaded, is reported DEAD."""
+        registry = OpenRouterModelRegistry.get_instance()
+        _populate_google(registry, ["gemini-2.5-flash"])
+
+        # Catalog exists for GOOGLE but does not contain this slug → dead.
+        assert not VerifiedModels.is_slug_live("gemini-totally-fake", ProviderType.GOOGLE)
+
+    def test_fails_soft_with_no_catalog(self):
+        """No catalog loaded → cannot assert death → fail soft (return True)."""
+        registry = OpenRouterModelRegistry.get_instance()
+        assert registry.google_model_count == 0
+        # Even a fabricated slug returns True because absence of a catalog is
+        # not evidence the slug is dead.
+        assert VerifiedModels.is_slug_live("gemini-totally-fake", ProviderType.GOOGLE)
+
+
+# ---------------------------------------------------------------------------
+# Resolver guard — find_money._resolve_quick_sim_text_model
+# ---------------------------------------------------------------------------
+@pytest.mark.fast
+class TestResolverGuard:
+    def test_live_slug_resolves_unchanged(self):
+        from app.api.v1.find_money import _resolve_quick_sim_text_model
+
+        registry = OpenRouterModelRegistry.get_instance()
+        _populate_google(registry, ["gemini-2.5-flash", "gemini-2.0-flash"])
+        _populate_openrouter(registry, ["anthropic/claude-opus-4.8"])
+
+        assert _resolve_quick_sim_text_model(None) == "gemini-2.5-flash"
+        assert _resolve_quick_sim_text_model("fast") == "gemini-2.0-flash"
+        assert _resolve_quick_sim_text_model("frontier") == "anthropic/claude-opus-4.8"
+
+    def test_dead_nonfrontier_slug_falls_back_loud(self, caplog):
+        from app.api.v1.find_money import _QUICK_SIM_TEXT_MODEL, _resolve_quick_sim_text_model
+
+        registry = OpenRouterModelRegistry.get_instance()
+        # Catalog has the default but NOT the 'fast' depth slug → fast is dead.
+        _populate_google(registry, ["gemini-2.5-flash"])
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            resolved = _resolve_quick_sim_text_model("fast")
+        assert resolved == _QUICK_SIM_TEXT_MODEL == "gemini-2.5-flash"
+        assert any("DEAD" in r.message for r in caplog.records)
+
+    def test_dead_frontier_slug_raises(self):
+        from app.api.v1.find_money import (
+            DeadFrontierSlugError,
+            _resolve_quick_sim_text_model,
+        )
+
+        registry = OpenRouterModelRegistry.get_instance()
+        # OpenRouter catalog exists but the frontier slug is absent → dead.
+        _populate_openrouter(registry, ["google/gemini-2.0-flash-001"])
+
+        with pytest.raises(DeadFrontierSlugError):
+            _resolve_quick_sim_text_model("frontier")
+
+    def test_no_catalog_resolves_unchanged(self):
+        """With no catalog loaded the resolver fails soft (no regression)."""
+        from app.api.v1.find_money import _resolve_quick_sim_text_model
+
+        registry = OpenRouterModelRegistry.get_instance()
+        assert registry.google_model_count == 0
+        assert registry.model_count == 0
+        # All tiers resolve to their configured slug, frontier does NOT raise.
+        assert _resolve_quick_sim_text_model(None) == "gemini-2.5-flash"
+        assert _resolve_quick_sim_text_model("frontier") == "anthropic/claude-opus-4.8"
+
+
+# ---------------------------------------------------------------------------
+# _simulate_one fails + the batch refunds on a dead frontier slug
+# ---------------------------------------------------------------------------
+@pytest.mark.fast
+class TestSimulateOneFrontierFailure:
+    def test_simulate_one_dead_frontier_returns_failure_not_garbage(self):
+        import asyncio
+
+        from app.api.v1.find_money import _simulate_one
+        from app.schemas.quick_sim import OpportunityIn
+
+        registry = OpenRouterModelRegistry.get_instance()
+        # Frontier slug is dead (catalog loaded, slug absent).
+        _populate_openrouter(registry, ["google/gemini-2.0-flash-001"])
+
+        result = asyncio.run(
+            _simulate_one(
+                index=0,
+                goal="$50k grant",
+                opportunity=OpportunityIn(title="Climate Fund", summary="..."),
+                preset=None,
+                user_id=None,
+                depth="frontier",
+            )
+        )
+        assert result["success"] is False
+        assert result["quick_sim"] is None  # never emits a garbage score
+        assert result["tdf"] is None
+        assert "frontier model unavailable" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# CI guard — every configured slug must resolve live against a real catalog
+# ---------------------------------------------------------------------------
+@pytest.mark.fast
+class TestEnumerateConfiguredSlugs:
+    def test_all_configured_text_slugs_enumerated(self):
+        """The enumeration covers GOOGLE_TEXT, OPENROUTER_TEXT, the depth map,
+        and the text fallback chain — so the CI guard can't miss a list."""
+        slugs = {s for s, _ in VerifiedModels.all_configured_text_slugs()}
+        # Spot-check representatives from each source list.
+        assert "gemini-2.5-flash" in slugs  # GOOGLE_TEXT
+        assert "gemini-2.0-flash" in slugs  # depth map (fast) + GOOGLE_TEXT
+        assert "anthropic/claude-opus-4.8" in slugs  # OPENROUTER_TEXT / frontier
+        assert "google/gemini-2.0-flash-001" in slugs  # fallback chain
+
+    def test_ci_guard_catches_a_dead_slug(self):
+        """Simulate CI: enumerate every slug, assert each is live. A catalog
+        missing one of them makes the guard fail loud (the dead-slug failure
+        mode becomes a red CI rather than silent prod garbage)."""
+        registry = OpenRouterModelRegistry.get_instance()
+        all_slugs = VerifiedModels.all_configured_text_slugs()
+
+        google_slugs = [s for s, p in all_slugs if p == ProviderType.GOOGLE]
+        or_slugs = [s for s, p in all_slugs if p == ProviderType.OPENROUTER]
+
+        # Seed catalogs with EVERY configured slug EXCEPT one frontier slug.
+        _populate_google(registry, google_slugs)
+        live_or = [s for s in or_slugs if s != "anthropic/claude-opus-4.8"]
+        _populate_openrouter(registry, live_or)
+
+        dead = [s for s, p in all_slugs if not VerifiedModels.is_slug_live(s, p)]
+        assert dead == ["anthropic/claude-opus-4.8"]
+
+        # And when the catalog is complete, nothing is dead.
+        _populate_openrouter(registry, or_slugs)
+        dead_complete = [s for s, p in all_slugs if not VerifiedModels.is_slug_live(s, p)]
+        assert dead_complete == []

--- a/tests/unit/test_model_slug_liveness.py
+++ b/tests/unit/test_model_slug_liveness.py
@@ -128,7 +128,9 @@ class TestRegistryLiveness:
         registry = OpenRouterModelRegistry.get_instance()
         _populate_openrouter(registry, ["anthropic/claude-opus-4.8"])
         assert registry.is_slug_live("anthropic/claude-opus-4.8", ProviderType.OPENROUTER)
-        assert not registry.is_slug_live("anthropic/claude-3-5-haiku-20241022", ProviderType.OPENROUTER)
+        assert not registry.is_slug_live(
+            "anthropic/claude-3-5-haiku-20241022", ProviderType.OPENROUTER
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a model-slug liveness guard over VerifiedModels and a quick-sim depth dial.

Note: merge != production deploy (live Flash deploys from a private fork, not this public upstream).
Swarm-built and adversarially verified.