### PR TITLE
chore: bump codecov-action to v5 (node24 migration)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           pytest -m fast -v --cov=app --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
GitHub Actions node20→node24 migration (effective 6/16). `codecov/codecov-action@v4` is node20-based; v5 is a composite action with no node runtime pin. Only outdated action found in this repo — all other `actions/*` were already on current node24-ready majors.